### PR TITLE
workflows: add permissions and triggering "on pull request"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 name: Coverage
-on: [ "push" ]
+on: [ "pull_request" ]
+permissions: read-all
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 name: DCO Validator
-on: [ "push" ]
-
+on:
+  pull_request:
+    types: [opened, synchronize]
+permissions: read-all
 jobs:
   dco-gpg-validator:
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 name: License
-on: [ "push" ]
+on: [ "pull_request" ]
+permissions: read-all
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 name: Lint
-on: [ "push" ]
+on: [ "pull_request" ]
+permissions: read-all
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 name: Security
-on: [ "push" ]
+on: [ "pull_request" ]
+permissions: read-all
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 name: Test
-on: [ "push" ]
+on: [ "pull_request" ]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
This commit change the workflows to run only on pull requests instead on
push. With this change pull requests from contributors outside the ZupIT
organization will run.

Signed-off-by: Ian Cardoso <ian.cardoso@zup.com.br>
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
