### PR TITLE
ir:feat - initial implementation of AST to IR conversion

### DIFF
--- a/internal/ir/builder.go
+++ b/internal/ir/builder.go
@@ -1,0 +1,130 @@
+// Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:funlen // We need a lot of lines and if to convert an AST to IR.
+package ir
+
+import (
+	"fmt"
+
+	"github.com/ZupIT/horusec-engine/internal/ast"
+)
+
+// Build the IR code for this function.
+func (fn *Function) Build() {
+	var b builder
+
+	var body *ast.BlockStmt
+
+	switch s := fn.syntax.(type) {
+	case *ast.FuncDecl:
+		body = s.Body
+	case *ast.FuncLit:
+		body = s.Body
+	default:
+		panic(fmt.Sprintf("ir.Function.Build: invalid syntax node of function: %T", s))
+	}
+
+	b.buildFunction(fn, body)
+}
+
+// newBasicBlock adds to fn a new basic block and returns it.
+// comment is an optional string for more readable debugging output.
+//
+// It does not automatically become the current block for subsequent calls to emit.
+func (fn *Function) newBasicBlock(comment string) *BasicBlock {
+	b := &BasicBlock{
+		Comment: comment,
+		Instrs:  make([]Instruction, 0),
+	}
+
+	fn.Blocks = append(fn.Blocks, b)
+
+	return b
+}
+
+// emit add a new instruction on current basic block of function.
+func (fn *Function) emit(instr Instruction) {
+	fn.currentBlock.Instrs = append(fn.currentBlock.Instrs, instr)
+}
+
+// appendLocal create a new local Var on function context to a given ident and value.
+func (fn *Function) appendLocal(ident *ast.Ident, value ast.Expr) {
+	fn.Locals[ident.Name] = &Var{
+		name:  ident.Name,
+		Value: exprValue(value),
+	}
+}
+
+// builder controls how a function is converted from AST to a IR.
+//
+// Its methods contain all the logic for AST-to-IR conversion.
+type builder struct{}
+
+// buildFunction builds IR code for the body of function fn.
+func (b *builder) buildFunction(fn *Function, body *ast.BlockStmt) {
+	fn.currentBlock = fn.newBasicBlock("entry")
+	b.stmt(fn, body)
+	fn.finishBody()
+}
+
+// finishBody finalizes the function after IR code generation of its body.
+func (fn *Function) finishBody() {
+	fn.currentBlock = nil
+}
+
+// stmt convert a statement s to a IR form.
+//
+// nolint:gocyclo // Its better centralize all stmt to IR conversion on a single function.
+func (b *builder) stmt(fn *Function, s ast.Stmt) {
+	switch stmt := s.(type) {
+	case *ast.BlockStmt:
+		b.stmtList(fn, stmt.List)
+	case *ast.ExprStmt:
+		b.expr(fn, stmt.Expr)
+	case *ast.AssignStmt:
+		// Handle a, b = 1, 2
+		if len(stmt.LHS) == len(stmt.RHS) {
+			for idx := range stmt.LHS {
+				lh, rh := stmt.LHS[idx], stmt.RHS[idx]
+				// TODO(matheus): lh will always be an *ast.Ident?
+				fn.appendLocal(lh.(*ast.Ident), rh)
+			}
+
+			break
+		}
+		// TODO(matheus): Handle cases like a, b = foo()
+		panic("ir.builder.stmt: not implemented tuple assignments")
+	default:
+		panic(fmt.Sprintf("ir.builder.stmt: unhandled expression type: %T", stmt))
+	}
+}
+
+// expr convert an expression e to a IR form.
+//
+func (b *builder) expr(fn *Function, e ast.Expr) {
+	switch expr := e.(type) {
+	case *ast.CallExpr:
+		fn.emit(newCall(fn, expr))
+	default:
+		panic(fmt.Sprintf("ir.builder.expr: unhandled expression type: %T", expr))
+	}
+}
+
+// stmtList emits to fn code for all statements in list.
+func (b *builder) stmtList(fn *Function, list []ast.Stmt) {
+	for _, s := range list {
+		b.stmt(fn, s)
+	}
+}

--- a/internal/ir/create.go
+++ b/internal/ir/create.go
@@ -1,0 +1,126 @@
+// Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:funlen // We need a lot of lines and if to convert an AST to IR.
+package ir
+
+import (
+	"fmt"
+
+	"github.com/ZupIT/horusec-engine/internal/ast"
+)
+
+// NewFunction create a new Function to a given function declaration.
+//
+// The real work of building the IR form for a function is not done
+// until a call to Function.Build().
+func NewFunction(decl *ast.FuncDecl) *Function {
+	var (
+		params  []*Parameter
+		results []*Parameter
+		fn      = &Function{
+			Name:   decl.Name.Name,
+			syntax: decl,
+			Blocks: make([]*BasicBlock, 0),
+			Locals: make(map[string]*Var),
+		}
+	)
+
+	if decl.Type.Params != nil {
+		params = make([]*Parameter, 0, len(decl.Type.Params.List))
+		for _, p := range decl.Type.Params.List {
+			params = append(params, newParameter(fn, p.Name))
+		}
+	}
+
+	if decl.Type.Results != nil {
+		results = make([]*Parameter, 0, len(decl.Type.Results.List))
+		for _, p := range decl.Type.Results.List {
+			results = append(results, newParameter(fn, p.Name))
+		}
+	}
+
+	fn.Signature = &Signature{params, results}
+
+	return fn
+}
+
+// newParameter return a new Parameter to a given expression.
+func newParameter(fn *Function, expr ast.Expr) *Parameter {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		return &Parameter{
+			parent: fn,
+			Name:   expr.Name,
+			Value:  nil,
+		}
+	default:
+		panic(fmt.Sprintf("ir.newParameter: unhandled expression type: %T", expr))
+	}
+}
+
+// exprValue lowers a single-result expression e to IR form and return the Value defined by the expression.
+func exprValue(e ast.Expr) Value {
+	switch expr := e.(type) {
+	case *ast.BasicLit:
+		return &Const{expr.Value}
+	case *ast.Ident:
+		return &Var{
+			name:  expr.Name,
+			Value: nil,
+		}
+	default:
+		panic(fmt.Sprintf("ir.newValue: unhandled expression type: %T", expr))
+	}
+}
+
+// newCall create new Call to a given ast.CallExpr
+//
+// If CallExpr arguments use a variable declared inside parent function
+// call arguments will point to to this declared variable.
+//
+// nolint:gocritic // More switch cases will be added.
+func newCall(parent *Function, call *ast.CallExpr) *Call {
+	args := make([]Value, 0, len(call.Args))
+
+	for _, arg := range call.Args {
+		if ident, ok := arg.(*ast.Ident); ok {
+			// If identifier used on function call is declared inside the parent function
+			// we use this declared variable as argument to function call.
+			if local, exists := parent.Locals[ident.Name]; exists {
+				args = append(args, local)
+
+				continue
+			}
+		}
+		args = append(args, exprValue(arg))
+	}
+
+	var fn Function
+
+	switch call := call.Fun.(type) {
+	case *ast.Ident:
+		// TODO(matheus): Check if this function is declared inside the module that parent belongs
+		// if its presents use this function function pointer on Call structure.
+		//
+		// Note: We still don't have a module representation to fix this.
+		fn.Name = call.Name
+	}
+
+	return &Call{
+		Parent:   parent,
+		Function: &fn,
+		Args:     args,
+	}
+}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -1,0 +1,95 @@
+// Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import (
+	"github.com/ZupIT/horusec-engine/internal/ast"
+)
+
+// Value is an IR value that can be referenced by an instruction.
+type Value interface {
+	value()
+
+	// Name returns the name of this value, and determines how
+	// this Value appears when used as an operand of an
+	// Instruction.
+	//
+	// This is the same as the source name for Parameters,
+	// Functions and Vars.
+	// For constants, it is a representation of the constant's value
+	Name() string
+}
+
+// Instruction is an IR instruction that computes a new Value or has some effect.
+type Instruction interface {
+	instr()
+}
+
+// BasicBlock represents an IR basic block.
+type BasicBlock struct {
+	Comment string        // Optional label; no semantic significance
+	Instrs  []Instruction // Instructions in order.
+}
+
+// Function represents a function or method with the parameters and signature.
+type Function struct {
+	Name      string          // Function name.
+	Signature *Signature      // Function signature.
+	Locals    map[string]*Var // Local variables of this function.
+	Blocks    []*BasicBlock   // Basic blocks of the function; nil => external function.
+
+	syntax ast.Node // AST node that represents the Function.
+
+	// The following fields are set transiently during building,
+	// then cleared.
+	currentBlock *BasicBlock // Where to add instructions.
+}
+
+// Signature represents a function or method signature.
+type Signature struct {
+	Params  []*Parameter // Parameters from left to right; or nil
+	Results []*Parameter // Return values from left to right; or nil
+}
+
+// Parameter represents an input parameter of a function or method.
+type Parameter struct {
+	Name  string // Name of parameter.
+	Value Value  // Default value of parameter or nil.
+
+	parent *Function // Function that the this parameter belongs.
+}
+
+// Const represents the value of a constant expression.
+type Const struct {
+	Value string // Value of constant.
+}
+
+// Var represents a variable
+type Var struct {
+	name  string // Name of variable.
+	Value Value  // Value of variable
+}
+
+// Call instruction represents a function or method call.
+type Call struct {
+	Parent   *Function // Function that Call is inside.
+	Function *Function // The function that is being called.
+	Args     []Value   // The call function parameters.
+}
+
+func (*Const) value() {}
+func (*Var) value()   {}
+
+func (*Call) instr() {}

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -1,0 +1,38 @@
+// Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ir
+
+import (
+	"bytes"
+)
+
+func (c *Call) String() string {
+	buf := bytes.NewBufferString(c.Function.Name)
+	buf.WriteString("(")
+
+	for i, arg := range c.Args {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(arg.Name())
+	}
+
+	buf.WriteString(")")
+
+	return buf.String()
+}
+
+func (c *Const) Name() string { return c.Value }
+func (v *Var) Name() string   { return v.name }


### PR DESCRIPTION
This commit introduce a initial implementation of AST to IR conversion.

The new package IR declared two basic interfaces; Value and Instruction.
Value are IR nodes that holds a value that could be references by an
Instruction, like a variable or a constant value. Instruction on the
other hand are IR nodes that can compute a value or has some effect,
like binary expressions or call expressions.

The implementation is mostly based on golang.org/x/tools/go/ssa [1]
package.

The currently implementation only support call expressions and variable
declarations inside a function. The remaining conversions will be
implemented in the following commits with some test cases.

[1] https://pkg.go.dev/golang.org/x/tools@v0.1.8/go/ssa

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>
