### PR TITLE
ast,javascript:chore - add alias identifier on ImportDecl

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -381,8 +381,9 @@ type (
 	// ImportDecl node represents a single package/module import.
 	ImportDecl struct {
 		Position
-		Name *Ident // Import name.
-		Path *Ident // Import path.
+		Name  *Ident // Import name.
+		Alias *Ident // Alias name or nil.
+		Path  *Ident // Import path.
 	}
 
 	// ValueDecl node represents a constant or variable declaration.

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -195,6 +195,9 @@ func Walk(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+		if n.Alias != nil {
+			Walk(v, n.Alias)
+		}
 		if n.Path != nil {
 			Walk(v, n.Path)
 		}

--- a/internal/horusec-javascript/ast.go
+++ b/internal/horusec-javascript/ast.go
@@ -647,6 +647,7 @@ func (p *parser) parseImportStmt(node *cst.Node) []ast.Decl {
 				imports = append(imports, &ast.ImportDecl{
 					Name:     ast.NewIdent(name),
 					Path:     ast.NewIdent(source),
+					Alias:    p.aliasFromImportStmt(importIdentifier),
 					Position: ast.NewPosition(node),
 				})
 			}
@@ -665,6 +666,17 @@ func (p *parser) parseImportStmt(node *cst.Node) []ast.Decl {
 	}
 
 	return []ast.Decl{}
+}
+
+// aliasFromImportStmt return an *ast.Ident with the alias name from import_specifier node.
+//
+// Return nil if import_specifier node don't have an alias.
+func (p *parser) aliasFromImportStmt(node *cst.Node) *ast.Ident {
+	if a := node.ChildByFieldName("alias"); a != nil {
+		return ast.NewIdent(a)
+	}
+
+	return nil
 }
 
 func (p *parser) parseCallExpr(node *cst.Node) *ast.CallExpr {

--- a/internal/horusec-javascript/testdata/expected/imports.js.out
+++ b/internal/horusec-javascript/testdata/expected/imports.js.out
@@ -4,101 +4,94 @@
      3  .  .  Name: "imports.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 9) {
+     6  .  Decls: []ast.Decl (len = 8) {
      7  .  .  0: *ast.ImportDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
-    10  .  .  .  .  Name: "foo"
+    10  .  .  .  .  Name: "fs"
     11  .  .  .  .  Position: ast.Position {}
     12  .  .  .  }
     13  .  .  .  Path: *ast.Ident {
-    14  .  .  .  .  Name: "bar"
+    14  .  .  .  .  Name: "fs"
     15  .  .  .  .  Position: ast.Position {}
     16  .  .  .  }
     17  .  .  }
     18  .  .  1: *ast.ImportDecl {
     19  .  .  .  Position: ast.Position {}
     20  .  .  .  Name: *ast.Ident {
-    21  .  .  .  .  Name: "foo"
+    21  .  .  .  .  Name: "net"
     22  .  .  .  .  Position: ast.Position {}
     23  .  .  .  }
     24  .  .  .  Path: *ast.Ident {
-    25  .  .  .  .  Name: "bar"
+    25  .  .  .  .  Name: "net"
     26  .  .  .  .  Position: ast.Position {}
     27  .  .  .  }
     28  .  .  }
     29  .  .  2: *ast.ImportDecl {
     30  .  .  .  Position: ast.Position {}
     31  .  .  .  Name: *ast.Ident {
-    32  .  .  .  .  Name: "foo"
+    32  .  .  .  .  Name: "spawn"
     33  .  .  .  .  Position: ast.Position {}
     34  .  .  .  }
     35  .  .  .  Path: *ast.Ident {
-    36  .  .  .  .  Name: "bar"
+    36  .  .  .  .  Name: "child_process"
     37  .  .  .  .  Position: ast.Position {}
     38  .  .  .  }
     39  .  .  }
     40  .  .  3: *ast.ImportDecl {
     41  .  .  .  Position: ast.Position {}
     42  .  .  .  Name: *ast.Ident {
-    43  .  .  .  .  Name: "foo"
+    43  .  .  .  .  Name: "Readable"
     44  .  .  .  .  Position: ast.Position {}
     45  .  .  .  }
     46  .  .  .  Path: *ast.Ident {
-    47  .  .  .  .  Name: "baz"
+    47  .  .  .  .  Name: "stream"
     48  .  .  .  .  Position: ast.Position {}
     49  .  .  .  }
     50  .  .  }
     51  .  .  4: *ast.ImportDecl {
     52  .  .  .  Position: ast.Position {}
     53  .  .  .  Name: *ast.Ident {
-    54  .  .  .  .  Name: "bar"
+    54  .  .  .  .  Name: "Writable"
     55  .  .  .  .  Position: ast.Position {}
     56  .  .  .  }
     57  .  .  .  Path: *ast.Ident {
-    58  .  .  .  .  Name: "baz"
+    58  .  .  .  .  Name: "stream"
     59  .  .  .  .  Position: ast.Position {}
     60  .  .  .  }
     61  .  .  }
     62  .  .  5: *ast.ImportDecl {
     63  .  .  .  Position: ast.Position {}
     64  .  .  .  Path: *ast.Ident {
-    65  .  .  .  .  Name: "foo"
+    65  .  .  .  .  Name: "process"
     66  .  .  .  .  Position: ast.Position {}
     67  .  .  .  }
     68  .  .  }
     69  .  .  6: *ast.ImportDecl {
     70  .  .  .  Position: ast.Position {}
     71  .  .  .  Name: *ast.Ident {
-    72  .  .  .  .  Name: "foo"
+    72  .  .  .  .  Name: "readFile"
     73  .  .  .  .  Position: ast.Position {}
     74  .  .  .  }
-    75  .  .  .  Path: *ast.Ident {
-    76  .  .  .  .  Name: "bar"
+    75  .  .  .  Alias: *ast.Ident {
+    76  .  .  .  .  Name: "fsRead"
     77  .  .  .  .  Position: ast.Position {}
     78  .  .  .  }
-    79  .  .  }
-    80  .  .  7: *ast.ImportDecl {
-    81  .  .  .  Position: ast.Position {}
-    82  .  .  .  Name: *ast.Ident {
-    83  .  .  .  .  Name: "foo"
-    84  .  .  .  .  Position: ast.Position {}
-    85  .  .  .  }
-    86  .  .  .  Path: *ast.Ident {
-    87  .  .  .  .  Name: "foo"
+    79  .  .  .  Path: *ast.Ident {
+    80  .  .  .  .  Name: "fs"
+    81  .  .  .  .  Position: ast.Position {}
+    82  .  .  .  }
+    83  .  .  }
+    84  .  .  7: *ast.ImportDecl {
+    85  .  .  .  Position: ast.Position {}
+    86  .  .  .  Name: *ast.Ident {
+    87  .  .  .  .  Name: "os"
     88  .  .  .  .  Position: ast.Position {}
     89  .  .  .  }
-    90  .  .  }
-    91  .  .  8: *ast.ImportDecl {
-    92  .  .  .  Position: ast.Position {}
-    93  .  .  .  Name: *ast.Ident {
-    94  .  .  .  .  Name: "foo"
-    95  .  .  .  .  Position: ast.Position {}
-    96  .  .  .  }
-    97  .  .  .  Path: *ast.Ident {
-    98  .  .  .  .  Name: "bar"
-    99  .  .  .  .  Position: ast.Position {}
-   100  .  .  .  }
-   101  .  .  }
-   102  .  }
-   103  }
+    90  .  .  .  Path: *ast.Ident {
+    91  .  .  .  .  Name: "os"
+    92  .  .  .  .  Position: ast.Position {}
+    93  .  .  .  }
+    94  .  .  }
+    95  .  }
+    96  }

--- a/internal/horusec-javascript/testdata/source/imports.js
+++ b/internal/horusec-javascript/testdata/source/imports.js
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-import * as foo from 'bar'
+import * as fs from 'fs'
 
-import foo from 'bar'
+import net from 'net'
 
-import { foo } from 'bar';
+import { spawn } from 'child_process';
 
-import { foo, bar } from 'baz';
+import { Readable, Writable } from 'stream';
 
-import 'foo'
+import 'process'
 
-import { foo as baz } from 'bar';
+import { readFile as fsRead } from 'fs';
 
-const foo = require('foo')
-
-const foo = require('bar')
+const os = require('os');


### PR DESCRIPTION
Previously when a import statement is declared using an alias, this
alias name was being ignored by AST. This commit add a new field Alias
on ImportDecl struct node to store this alias name if exists.

The test cases of import statement was also change to more easily
reading, avoiding generic and duplicate import names like foo, bar. 

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>
