### PR TITLE
javascript/ast:feat - add support to #nosec directives

### DIFF
--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -50,7 +50,7 @@ func Walk(v Visitor, node Node) {
 	// of the corresponding node types in ast.go)
 	switch n := node.(type) {
 	// Expressions
-	case *Ident, *BasicLit, *BadNode:
+	case *Ident, *BasicLit, *BadNode, *Comment:
 		// Nothing to do.
 	case *Field:
 		if n.Name != nil {

--- a/internal/testdata/expected/javascript/ast/comments-2.js.out
+++ b/internal/testdata/expected/javascript/ast/comments-2.js.out
@@ -1,0 +1,7 @@
+     0  *ast.File {
+     1  .  Position: ast.Position {}
+     2  .  Name: *ast.Ident {
+     3  .  .  Name: "comments-2.js"
+     4  .  .  Position: ast.Position {}
+     5  .  }
+     6  }

--- a/internal/testdata/expected/javascript/ast/comments.js.out
+++ b/internal/testdata/expected/javascript/ast/comments.js.out
@@ -1,0 +1,108 @@
+     0  *ast.File {
+     1  .  Position: ast.Position {}
+     2  .  Name: *ast.Ident {
+     3  .  .  Name: "comments.js"
+     4  .  .  Position: ast.Position {}
+     5  .  }
+     6  .  Decls: []ast.Decl (len = 2) {
+     7  .  .  0: *ast.FuncDecl {
+     8  .  .  .  Position: ast.Position {}
+     9  .  .  .  Name: *ast.Ident {
+    10  .  .  .  .  Name: "f3"
+    11  .  .  .  .  Position: ast.Position {}
+    12  .  .  .  }
+    13  .  .  .  Type: *ast.FuncType {
+    14  .  .  .  .  Position: ast.Position {}
+    15  .  .  .  .  Params: *ast.FieldList {
+    16  .  .  .  .  .  Position: ast.Position {}
+    17  .  .  .  .  }
+    18  .  .  .  }
+    19  .  .  .  Body: *ast.BlockStmt {
+    20  .  .  .  .  Position: ast.Position {}
+    21  .  .  .  .  List: []ast.Stmt (len = 2) {
+    22  .  .  .  .  .  0: *ast.ExprStmt {
+    23  .  .  .  .  .  .  Position: ast.Position {}
+    24  .  .  .  .  .  .  Expr: *ast.CallExpr {
+    25  .  .  .  .  .  .  .  Position: ast.Position {}
+    26  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+    27  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    28  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+    29  .  .  .  .  .  .  .  .  .  Name: "console"
+    30  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    31  .  .  .  .  .  .  .  .  }
+    32  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+    33  .  .  .  .  .  .  .  .  .  Name: "log"
+    34  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    35  .  .  .  .  .  .  .  .  }
+    36  .  .  .  .  .  .  .  }
+    37  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+    38  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+    39  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    40  .  .  .  .  .  .  .  .  .  Kind: "string"
+    41  .  .  .  .  .  .  .  .  .  Value: "f3-2"
+    42  .  .  .  .  .  .  .  .  }
+    43  .  .  .  .  .  .  .  }
+    44  .  .  .  .  .  .  }
+    45  .  .  .  .  .  }
+    46  .  .  .  .  .  1: *ast.ExprStmt {
+    47  .  .  .  .  .  .  Position: ast.Position {}
+    48  .  .  .  .  .  .  Expr: *ast.CallExpr {
+    49  .  .  .  .  .  .  .  Position: ast.Position {}
+    50  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+    51  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    52  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+    53  .  .  .  .  .  .  .  .  .  Name: "console"
+    54  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    55  .  .  .  .  .  .  .  .  }
+    56  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+    57  .  .  .  .  .  .  .  .  .  Name: "log"
+    58  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    59  .  .  .  .  .  .  .  .  }
+    60  .  .  .  .  .  .  .  }
+    61  .  .  .  .  .  .  .  Args: []ast.Expr (len = 2) {
+    62  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+    63  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    64  .  .  .  .  .  .  .  .  .  Kind: "string"
+    65  .  .  .  .  .  .  .  .  .  Value: "f3-3"
+    66  .  .  .  .  .  .  .  .  }
+    67  .  .  .  .  .  .  .  .  1: *ast.Comment {
+    68  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    69  .  .  .  .  .  .  .  .  .  Text: `/* #nosec */`
+    70  .  .  .  .  .  .  .  .  }
+    71  .  .  .  .  .  .  .  }
+    72  .  .  .  .  .  .  }
+    73  .  .  .  .  .  }
+    74  .  .  .  .  }
+    75  .  .  .  }
+    76  .  .  }
+    77  .  .  1: *ast.ClassDecl {
+    78  .  .  .  Position: ast.Position {}
+    79  .  .  .  Name: *ast.Ident {
+    80  .  .  .  .  Name: "Foo"
+    81  .  .  .  .  Position: ast.Position {}
+    82  .  .  .  }
+    83  .  .  .  Body: *ast.BodyDecl {
+    84  .  .  .  .  Position: ast.Position {}
+    85  .  .  .  .  List: []ast.Decl (len = 1) {
+    86  .  .  .  .  .  0: *ast.FuncDecl {
+    87  .  .  .  .  .  .  Position: ast.Position {}
+    88  .  .  .  .  .  .  Name: *ast.Ident {
+    89  .  .  .  .  .  .  .  Name: "bar"
+    90  .  .  .  .  .  .  .  Position: ast.Position {}
+    91  .  .  .  .  .  .  }
+    92  .  .  .  .  .  .  Type: *ast.FuncType {
+    93  .  .  .  .  .  .  .  Position: ast.Position {}
+    94  .  .  .  .  .  .  .  Params: *ast.FieldList {
+    95  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    96  .  .  .  .  .  .  .  }
+    97  .  .  .  .  .  .  }
+    98  .  .  .  .  .  .  Body: *ast.BlockStmt {
+    99  .  .  .  .  .  .  .  Position: ast.Position {}
+   100  .  .  .  .  .  .  .  List: []ast.Stmt (len = 0) {}
+   101  .  .  .  .  .  .  }
+   102  .  .  .  .  .  }
+   103  .  .  .  .  }
+   104  .  .  .  }
+   105  .  .  }
+   106  .  }
+   107  }

--- a/internal/testdata/source/javascript/comments-2.js
+++ b/internal/testdata/source/javascript/comments-2.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #nosec  // The entire source file should be ignored
+
+
+function f(a, b) {
+    return a + b;
+}

--- a/internal/testdata/source/javascript/comments.js
+++ b/internal/testdata/source/javascript/comments.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Function documentation
+// Suspendisse potenti. Integer porttitor elit non urna viverra pretium. Mauris aliquam condimentum tempus. Nullam mi 
+// massa, porttitor nec tincidunt nec, posuere dapibus libero. Sed id tortor purus.
+//
+// #nosec
+function f1() {}
+
+/* 
+    * #nosec
+*/
+function f2() {}
+
+function f3() {
+    // #nosec // This syntax is supported.
+    console.log("f3-1 ignored")
+
+    console.log("f3-2") // #nosec // This syntax is not supported.
+
+    console.log("f3-3" /* #nosec */)  // This syntax is not supported.
+}
+
+class Foo {
+    bar() {
+    // #nosec 
+    console.log("Foo.bar");
+    }
+
+    // #nosec
+    baz() {}
+}
+
+
+// #nosec
+class Bar {}
+
+
+// #nosec
+const a = 20
+


### PR DESCRIPTION
This commit introduce support to ignore block of codes using #nosec
comments.

The nosec directive can be used in any code block, the only requirement is
that the comment must be on the top line of the code that should be ignored,
comments on the same or below or more than one line above are not supported.
To view supported syntaxes see test file
internal/testdata/source/javascript/comments.js.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
