### PR TITLE
ir:feat - improve support of ast.SelectorExpr

### DIFF
--- a/internal/ir/builder.go
+++ b/internal/ir/builder.go
@@ -208,6 +208,21 @@ func (b *builder) expr(fn *Function, e ast.Expr, expand bool) Value {
 			Value: expr.Value,
 			Subs:  values,
 		}
+	case *ast.SelectorExpr:
+		// TODO(matheus): If the variable value is an ast.SelectorExpr a new variable is
+		// create, but when printing this variable, their value will nil, because here we
+		// are creating a variable without a value. Maybe we should create a new IR Value
+		// that represents values that are references to other variables.
+		//
+		// E.g:
+		// const a = b.c.d
+		//
+		// IR:
+		// a = nil
+		//
+		// Expected IR:
+		// a = b.c.d
+		return b.selectorExpr(fn, expr)
 
 	// Value's that are also Instruction's.
 	case *ast.FuncLit:
@@ -228,6 +243,48 @@ func (b *builder) expr(fn *Function, e ast.Expr, expand bool) Value {
 	}
 
 	return v
+}
+
+// selectorExpr return the Value of a selector expression.
+//
+// The value returned will be a selector expression entire resolve. If the selector
+// expression contains call expressions, these expressions will be separated and temp
+// variables will be created to store these call expressions and these local variables
+// will be used on the resolve selector expression string.
+//
+// Example:
+// Source: a.b.c()
+// Return: Var{name: a.b.c()}
+// Source: a.b().c.d()
+// Return: Var{name: %t0.c.d()} // Where %t0 store the a.b() call expression.
+//
+// The expr value is expected to be an *ast.SelectorExpr. Since the selector expression
+// can contains other selector expressions, its necessary to expected an ast.Expr to
+// resolve recursivily *ast.SelectorExpr.
+func (b *builder) selectorExpr(fn *Function, expr ast.Expr) Value {
+	var name string
+
+	switch e := expr.(type) {
+	case *ast.Ident:
+		// e.Name could be an alias imported name, so we need to check if this
+		// identifier is imported so we use your real name. Otherwise we just
+		// use the expression identifier name.
+		if importt := fn.File.ImportedPackage(e.Name); importt != nil {
+			name = importt.Path
+		} else {
+			name = e.Name
+		}
+	case *ast.SelectorExpr:
+		name = fmt.Sprintf("%s.%s", b.selectorExpr(fn, e.Expr).Name(), e.Sel.Name)
+	default:
+		return b.expr(fn, e, true /*expand */)
+	}
+
+	return &Var{
+		node:  node{expr},
+		name:  name,
+		Value: nil,
+	}
 }
 
 // assignStmt emits code to fn for a parallel assignment of rhss to lhss.
@@ -253,6 +310,8 @@ func (b *builder) assign(fn *Function, lhs, rhs ast.Expr, syntax *ast.AssignStmt
 	switch lhs := lhs.(type) {
 	case *ast.Ident:
 		b.assignValue(fn, lhs, rhs, syntax)
+	case *ast.SelectorExpr:
+		fn.addNamedLocal(b.selectorExpr(fn, lhs).Name(), b.expr(fn, rhs, false /*expand*/), syntax)
 	default:
 		unsupportedNode(lhs)
 	}
@@ -391,26 +450,7 @@ func (b *builder) callExpr(parent *Function, call *ast.CallExpr) *Call {
 		}
 		fn.name = call.Name
 	case *ast.SelectorExpr:
-		expr, ok := call.Expr.(*ast.Ident)
-		if !ok {
-			// TODO(matheus): Add support to call expressions using selector expressions.
-			// e.g: a.b.c()
-			unsupportedNode(call.Expr)
-			break
-		}
-
-		var ident string
-
-		// Expr.Name could be an alias imported name, so need to check if this
-		// identifier is imported so we use your real name. Otherwise we just
-		// use the expression identifier name.
-		if importt := parent.File.ImportedPackage(expr.Name); importt != nil {
-			ident = importt.name
-		} else {
-			ident = expr.Name
-		}
-
-		fn.name = fmt.Sprintf("%s.%s", ident, call.Sel.Name)
+		fn.name = b.selectorExpr(parent, call).Name()
 	default:
 		unsupportedNode(call)
 	}

--- a/internal/testdata/expected/javascript/ast/functions.js.out
+++ b/internal/testdata/expected/javascript/ast/functions.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "functions.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 10) {
+     6  .  Decls: []ast.Decl (len = 11) {
      7  .  .  0: *ast.ImportDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -848,5 +848,217 @@
    847  .  .  .  .  }
    848  .  .  .  }
    849  .  .  }
-   850  .  }
-   851  }
+   850  .  .  10: *ast.FuncDecl {
+   851  .  .  .  Position: ast.Position {}
+   852  .  .  .  Name: *ast.Ident {
+   853  .  .  .  .  Name: "f9"
+   854  .  .  .  .  Position: ast.Position {}
+   855  .  .  .  }
+   856  .  .  .  Type: *ast.FuncType {
+   857  .  .  .  .  Position: ast.Position {}
+   858  .  .  .  .  Params: *ast.FieldList {
+   859  .  .  .  .  .  Position: ast.Position {}
+   860  .  .  .  .  .  List: []*ast.Field (len = 1) {
+   861  .  .  .  .  .  .  0: *ast.Field {
+   862  .  .  .  .  .  .  .  Position: ast.Position {}
+   863  .  .  .  .  .  .  .  Name: *ast.Ident {
+   864  .  .  .  .  .  .  .  .  Name: "a"
+   865  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   866  .  .  .  .  .  .  .  }
+   867  .  .  .  .  .  .  }
+   868  .  .  .  .  .  }
+   869  .  .  .  .  }
+   870  .  .  .  }
+   871  .  .  .  Body: *ast.BlockStmt {
+   872  .  .  .  .  Position: ast.Position {}
+   873  .  .  .  .  List: []ast.Stmt (len = 5) {
+   874  .  .  .  .  .  0: *ast.ExprStmt {
+   875  .  .  .  .  .  .  Position: ast.Position {}
+   876  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   877  .  .  .  .  .  .  .  Position: ast.Position {}
+   878  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   879  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   880  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   881  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   882  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   883  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   884  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   885  .  .  .  .  .  .  .  .  .  .  .  Name: "a"
+   886  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   887  .  .  .  .  .  .  .  .  .  .  }
+   888  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   889  .  .  .  .  .  .  .  .  .  .  .  Name: "b"
+   890  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   891  .  .  .  .  .  .  .  .  .  .  }
+   892  .  .  .  .  .  .  .  .  .  }
+   893  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 0) {}
+   894  .  .  .  .  .  .  .  .  }
+   895  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   896  .  .  .  .  .  .  .  .  .  Name: "c"
+   897  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   898  .  .  .  .  .  .  .  .  }
+   899  .  .  .  .  .  .  .  }
+   900  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   901  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+   902  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   903  .  .  .  .  .  .  .  .  .  Kind: "number"
+   904  .  .  .  .  .  .  .  .  .  Value: "10"
+   905  .  .  .  .  .  .  .  .  }
+   906  .  .  .  .  .  .  .  }
+   907  .  .  .  .  .  .  }
+   908  .  .  .  .  .  }
+   909  .  .  .  .  .  1: *ast.ExprStmt {
+   910  .  .  .  .  .  .  Position: ast.Position {}
+   911  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   912  .  .  .  .  .  .  .  Position: ast.Position {}
+   913  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   914  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   915  .  .  .  .  .  .  .  .  Expr: *ast.SelectorExpr {
+   916  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   917  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   918  .  .  .  .  .  .  .  .  .  .  Name: "a"
+   919  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   920  .  .  .  .  .  .  .  .  .  }
+   921  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   922  .  .  .  .  .  .  .  .  .  .  Name: "b"
+   923  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   924  .  .  .  .  .  .  .  .  .  }
+   925  .  .  .  .  .  .  .  .  }
+   926  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   927  .  .  .  .  .  .  .  .  .  Name: "c"
+   928  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   929  .  .  .  .  .  .  .  .  }
+   930  .  .  .  .  .  .  .  }
+   931  .  .  .  .  .  .  .  Args: []ast.Expr (len = 0) {}
+   932  .  .  .  .  .  .  }
+   933  .  .  .  .  .  }
+   934  .  .  .  .  .  2: *ast.AssignStmt {
+   935  .  .  .  .  .  .  Position: ast.Position {}
+   936  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+   937  .  .  .  .  .  .  .  0: *ast.Ident {
+   938  .  .  .  .  .  .  .  .  Name: "a"
+   939  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   940  .  .  .  .  .  .  .  }
+   941  .  .  .  .  .  .  }
+   942  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+   943  .  .  .  .  .  .  .  0: *ast.CallExpr {
+   944  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   945  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   946  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   947  .  .  .  .  .  .  .  .  .  Expr: *ast.SelectorExpr {
+   948  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   949  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   950  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   951  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   952  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   953  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   954  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "a"
+   955  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   956  .  .  .  .  .  .  .  .  .  .  .  .  }
+   957  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   958  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "b"
+   959  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   960  .  .  .  .  .  .  .  .  .  .  .  .  }
+   961  .  .  .  .  .  .  .  .  .  .  .  }
+   962  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   963  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+   964  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   965  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+   966  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "10"
+   967  .  .  .  .  .  .  .  .  .  .  .  .  }
+   968  .  .  .  .  .  .  .  .  .  .  .  }
+   969  .  .  .  .  .  .  .  .  .  .  }
+   970  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   971  .  .  .  .  .  .  .  .  .  .  .  Name: "c"
+   972  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   973  .  .  .  .  .  .  .  .  .  .  }
+   974  .  .  .  .  .  .  .  .  .  }
+   975  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   976  .  .  .  .  .  .  .  .  .  .  Name: "d"
+   977  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   978  .  .  .  .  .  .  .  .  .  }
+   979  .  .  .  .  .  .  .  .  }
+   980  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   981  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+   982  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   983  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+   984  .  .  .  .  .  .  .  .  .  .  Value: "20"
+   985  .  .  .  .  .  .  .  .  .  }
+   986  .  .  .  .  .  .  .  .  }
+   987  .  .  .  .  .  .  .  }
+   988  .  .  .  .  .  .  }
+   989  .  .  .  .  .  }
+   990  .  .  .  .  .  3: *ast.AssignStmt {
+   991  .  .  .  .  .  .  Position: ast.Position {}
+   992  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+   993  .  .  .  .  .  .  .  0: *ast.Ident {
+   994  .  .  .  .  .  .  .  .  Name: "b"
+   995  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   996  .  .  .  .  .  .  .  }
+   997  .  .  .  .  .  .  }
+   998  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+   999  .  .  .  .  .  .  .  0: *ast.SelectorExpr {
+  1000  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1001  .  .  .  .  .  .  .  .  Expr: *ast.SelectorExpr {
+  1002  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1003  .  .  .  .  .  .  .  .  .  Expr: *ast.SelectorExpr {
+  1004  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1005  .  .  .  .  .  .  .  .  .  .  Expr: *ast.SelectorExpr {
+  1006  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1007  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1008  .  .  .  .  .  .  .  .  .  .  .  .  Name: "a"
+  1009  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1010  .  .  .  .  .  .  .  .  .  .  .  }
+  1011  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1012  .  .  .  .  .  .  .  .  .  .  .  .  Name: "b"
+  1013  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1014  .  .  .  .  .  .  .  .  .  .  .  }
+  1015  .  .  .  .  .  .  .  .  .  .  }
+  1016  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1017  .  .  .  .  .  .  .  .  .  .  .  Name: "c"
+  1018  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1019  .  .  .  .  .  .  .  .  .  .  }
+  1020  .  .  .  .  .  .  .  .  .  }
+  1021  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1022  .  .  .  .  .  .  .  .  .  .  Name: "d"
+  1023  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1024  .  .  .  .  .  .  .  .  .  }
+  1025  .  .  .  .  .  .  .  .  }
+  1026  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1027  .  .  .  .  .  .  .  .  .  Name: "e"
+  1028  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1029  .  .  .  .  .  .  .  .  }
+  1030  .  .  .  .  .  .  .  }
+  1031  .  .  .  .  .  .  }
+  1032  .  .  .  .  .  }
+  1033  .  .  .  .  .  4: *ast.AssignStmt {
+  1034  .  .  .  .  .  .  Position: ast.Position {}
+  1035  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1036  .  .  .  .  .  .  .  0: *ast.SelectorExpr {
+  1037  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1038  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1039  .  .  .  .  .  .  .  .  .  Name: "a"
+  1040  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1041  .  .  .  .  .  .  .  .  }
+  1042  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1043  .  .  .  .  .  .  .  .  .  Name: "b"
+  1044  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1045  .  .  .  .  .  .  .  .  }
+  1046  .  .  .  .  .  .  .  }
+  1047  .  .  .  .  .  .  }
+  1048  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1049  .  .  .  .  .  .  .  0: *ast.CallExpr {
+  1050  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1051  .  .  .  .  .  .  .  .  Fun: *ast.Ident {
+  1052  .  .  .  .  .  .  .  .  .  Name: "c"
+  1053  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1054  .  .  .  .  .  .  .  .  }
+  1055  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 0) {}
+  1056  .  .  .  .  .  .  .  }
+  1057  .  .  .  .  .  .  }
+  1058  .  .  .  .  .  }
+  1059  .  .  .  .  }
+  1060  .  .  .  }
+  1061  .  .  }
+  1062  .  }
+  1063  }

--- a/internal/testdata/expected/javascript/ir/functions.js.out
+++ b/internal/testdata/expected/javascript/ir/functions.js.out
@@ -9,6 +9,7 @@ file functions.js:
   func  f6 ()
   func  f7 (b)
   func  f8 (a)
+  func  f9 (a)
 
 
 
@@ -131,4 +132,25 @@ func f8(a):
 0:                                                                         entry
 	b = a
 	c = a
+
+# Name: f9
+# File: functions.js
+# Location: functions.js:69:0
+# Locals:
+#   0:	%t0
+#   1:	%t1
+#   2:	%t2
+#   3:	%t3
+#   4:	a
+#   5:	a.b
+#   6:	b
+func f9(a):
+0:                                                                         entry
+	%t0 = a.b()
+	%t1 = %t0.c("10")
+	%t2 = a.b.c()
+	%t3 = a.b("10")
+	a = %t3.c.d("20")
+	b = nil
+	a.b = c()
 

--- a/internal/testdata/source/javascript/functions.js
+++ b/internal/testdata/source/javascript/functions.js
@@ -65,3 +65,14 @@ function f8(a) {
 	const b = a
 	const c = b
 }
+
+function f9(a) {
+    a.b().c(10)
+    a.b.c()
+
+    const a = a.b(10).c.d(20)
+
+    const b = a.b.c.d.e
+
+    a.b = c()
+}


### PR DESCRIPTION
Previously we was supporting ast.SelectorExpr only if the Expr field was
a identifier, so this commit improve this support handling the Expr
field recursively and resolving identifier imports.

Now we support expressions like `a.b.c()` and `a.b().c.d()`. For
selector expressions that Expr could be a call expression, temp
variables will be created and these temp variable will be used on the
name of selector expression.

Example:
    const a = a.b(10).c.d(20)
IR:
    %t0 = a.b(10)
    %t1 = %t0.c.d(20)

This apply not only for call expression but any expression on
ast.SelectorExpr.Expr that is not an *ast.Ident or *ast.SelectorExpr.

The *ast.SelectorExpr is also resolved when assigning variable values, but
we still need to improve this. When assigning a variable with a selector
expression, a new variable will be created to this selector expression
with the entire selector expression as a name of variable, but when
printing the IR, the value of this variable will be nil, because the
variable created from the selector expression has a nil value. This is
referenced in a TODO on *ast.SelectorExpr case from builder.expr method.

Lastly, the *ast.SelectorExpr is also resolved when the LHS operand of
an assign expression is an *ast.SelectorExpr. We still can improve this
support in the future, for example, when assigning a field from a class
e.g `this.a = 10`, we should be able to parse the `this` expression as
a receiver parameter from ir.Function object.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>
