### PR TITLE
ir:feat - add support for if statements

### DIFF
--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -90,6 +90,8 @@ type BasicBlock struct {
 	Index   int           // Index of this block on Function that this block belongs.
 	Comment string        // Optional label; no semantic significance
 	Instrs  []Instruction // Instructions in order.
+	Preds   []*BasicBlock // Predecessors blocks.
+	Succs   []*BasicBlock // Successors blocks.
 }
 
 // Function represents a function or method with the parameters and signature.
@@ -262,6 +264,35 @@ type Closure struct {
 	Fn *Function // Closure function.
 }
 
+// If instruction transfers control to one of the two successors of
+// its owning block, depending on the boolean Cond: the first if true,
+// the second if false.
+//
+// An If instruction must be the last instruction of its containing
+// BasicBlock.
+//
+// Example printed form (Consider 1 as if.them block and 3 as if.done block)
+// 	if a > b goto 1 else 3
+//
+// The If implements Instruction interface.
+type If struct {
+	block *BasicBlock
+	Cond  Value
+}
+
+// Jump instruction transfers control to the sole successor of its
+// owning block.
+//
+// A Jump must be the last instruction of its containing BasicBlock.
+//
+// Example printed form (Consider 5 as a if.done block):
+// 	jump 5
+//
+// The Jump implements Instruction interface.
+type Jump struct {
+	block *BasicBlock
+}
+
 // node is a mix-in embedded by all IR nodes to provide source code information.
 //
 // Since node is embedded by all IR nodes (Value's and Instruction's), these nodes
@@ -319,6 +350,10 @@ func (*Closure) instr()           {}
 func (*Closure) value()           {}
 func (c *Closure) Name() string   { return c.Fn.Name() }
 func (c *Closure) String() string { return fmt.Sprintf("make closure %s ", c.Name()) }
+
+func (*If) instr() {}
+
+func (*Jump) instr() {}
 
 func (*Function) member()         {}
 func (fn *Function) Name() string { return fn.name }

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -21,6 +21,9 @@ import (
 	"sort"
 )
 
+// invalidBasicBlock represents an invalid basic block number to jump.
+const invalidBasicBlock = -1
+
 func (f *File) String() string {
 	return "file " + f.name
 }
@@ -67,6 +70,25 @@ func (r *Return) String() string {
 	}
 
 	return buf.String()
+}
+
+func (s *If) String() string {
+	// Be robust against malformed CFG.
+	tblock, fblock := invalidBasicBlock, invalidBasicBlock
+	if s.block != nil && len(s.block.Succs) == 2 {
+		tblock = s.block.Succs[0].Index
+		fblock = s.block.Succs[1].Index
+	}
+	return fmt.Sprintf("if %s goto %d else %d", s.Cond.Name(), tblock, fblock)
+}
+
+func (s *Jump) String() string {
+	// Be robust against malformed CFG.
+	block := invalidBasicBlock
+	if s.block != nil && len(s.block.Succs) == 1 {
+		block = s.block.Succs[0].Index
+	}
+	return fmt.Sprintf("jump %d", block)
 }
 
 // WriteTo writes to w a human-readable summary of file.

--- a/internal/testdata/expected/javascript/ir/statements.js.out
+++ b/internal/testdata/expected/javascript/ir/statements.js.out
@@ -1,0 +1,88 @@
+file statements.js:
+  func  ExportStatement ()
+  func  ForInStatement  ()
+  func  ForStatement    ()
+  func  IfStatement     (a, b)
+  func  SwitchStatement ()
+  func  TryStatement    ()
+  func  WhileStatement  ()
+
+
+
+============================
+
+# Name: ExportStatement
+# File: statements.js
+# Location: statements.js:99:0
+func ExportStatement():
+0:                                                                         entry
+
+# Name: ForInStatement
+# File: statements.js
+# Location: statements.js:91:0
+# Locals:
+#   0:	values
+func ForInStatement():
+0:                                                                         entry
+	values = nil
+
+# Name: ForStatement
+# File: statements.js
+# Location: statements.js:85:0
+func ForStatement():
+0:                                                                         entry
+
+# Name: IfStatement
+# File: statements.js
+# Location: statements.js:17:0
+# Locals:
+#   0:	%t0
+#   1:	%t2
+#   2:	%t4
+#   3:	a
+#   4:	c
+func IfStatement(a, b):
+0:                                                                         entry
+	%t0 = a >= "10"
+	if %t0 goto 1 else 3
+1:                                                                       if.then
+	a = b * "2"
+	jump 2
+2:                                                                       if.done
+	return a
+3:                                                                       if.else
+	%t2 = a <= "5"
+	if %t2 goto 4 else 6
+4:                                                                       if.then
+	a = b + a
+	jump 5
+5:                                                                       if.done
+	jump 2
+6:                                                                       if.else
+	a = a + b
+	c = a * "10"
+	%t4 = console.log(c)
+	jump 5
+7:                                                                   unreachable
+
+# Name: SwitchStatement
+# File: statements.js
+# Location: statements.js:67:0
+# Locals:
+#   0:	fruits
+func SwitchStatement():
+0:                                                                         entry
+	fruits = "Oranges"
+
+# Name: TryStatement
+# File: statements.js
+# Location: statements.js:30:0
+func TryStatement():
+0:                                                                         entry
+
+# Name: WhileStatement
+# File: statements.js
+# Location: statements.js:42:0
+func WhileStatement():
+0:                                                                         entry
+


### PR DESCRIPTION
This commit add support to represent if statements on IR. This
representation is using Control-flow graph[1].

To add this support some new structs was created:
- If: Represents the if statement instruction. Contains the condition
  value of if and a basic block.
- Jump: Represents a jump instruction. This jump is used to represents
  jumps on if statement, for example, a jump from if them to if done or
  if else to if done. This jump instruction will also be used in other
  instructions that are represented using CFG's.

This commit add the ir/statements.js.out file that contains the if
statements IR code generated. Since we don't support all statements from
this test yet, this file was rewrited  using the debug flag disabled, so
the statements that we don't support is represented as empty blocks.
Running this test with debug enabled will fail, so we can still catch
not implemented translations from AST to IR.

[1] https://en.wikipedia.org/wiki/Control-flow_graph

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
