### PR TITLE
ir:bugfix - fixing lookup for global values

### DIFF
--- a/internal/testdata/expected/javascript/ast/functions.js.out
+++ b/internal/testdata/expected/javascript/ast/functions.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "functions.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 13) {
+     6  .  Decls: []ast.Decl (len = 15) {
      7  .  .  0: *ast.ImportDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -1385,5 +1385,78 @@
   1384  .  .  .  .  }
   1385  .  .  .  }
   1386  .  .  }
-  1387  .  }
-  1388  }
+  1387  .  .  13: *ast.ValueDecl {
+  1388  .  .  .  Position: ast.Position {}
+  1389  .  .  .  Names: []*ast.Ident (len = 1) {
+  1390  .  .  .  .  0: *ast.Ident {
+  1391  .  .  .  .  .  Name: "i"
+  1392  .  .  .  .  .  Position: ast.Position {}
+  1393  .  .  .  .  }
+  1394  .  .  .  }
+  1395  .  .  .  Values: []ast.Expr (len = 1) {
+  1396  .  .  .  .  0: *ast.ObjectExpr {
+  1397  .  .  .  .  .  Position: ast.Position {}
+  1398  .  .  .  .  .  Elts: []ast.Expr (len = 3) {
+  1399  .  .  .  .  .  .  0: *ast.BasicLit {
+  1400  .  .  .  .  .  .  .  Position: ast.Position {}
+  1401  .  .  .  .  .  .  .  Kind: "number"
+  1402  .  .  .  .  .  .  .  Value: "1"
+  1403  .  .  .  .  .  .  }
+  1404  .  .  .  .  .  .  1: *ast.BasicLit {
+  1405  .  .  .  .  .  .  .  Position: ast.Position {}
+  1406  .  .  .  .  .  .  .  Kind: "number"
+  1407  .  .  .  .  .  .  .  Value: "2"
+  1408  .  .  .  .  .  .  }
+  1409  .  .  .  .  .  .  2: *ast.BasicLit {
+  1410  .  .  .  .  .  .  .  Position: ast.Position {}
+  1411  .  .  .  .  .  .  .  Kind: "number"
+  1412  .  .  .  .  .  .  .  Value: "3"
+  1413  .  .  .  .  .  .  }
+  1414  .  .  .  .  .  }
+  1415  .  .  .  .  .  Comment: "array"
+  1416  .  .  .  .  }
+  1417  .  .  .  }
+  1418  .  .  }
+  1419  .  .  14: *ast.FuncDecl {
+  1420  .  .  .  Position: ast.Position {}
+  1421  .  .  .  Name: *ast.Ident {
+  1422  .  .  .  .  Name: "f12"
+  1423  .  .  .  .  Position: ast.Position {}
+  1424  .  .  .  }
+  1425  .  .  .  Type: *ast.FuncType {
+  1426  .  .  .  .  Position: ast.Position {}
+  1427  .  .  .  .  Params: *ast.FieldList {
+  1428  .  .  .  .  .  Position: ast.Position {}
+  1429  .  .  .  .  }
+  1430  .  .  .  }
+  1431  .  .  .  Body: *ast.BlockStmt {
+  1432  .  .  .  .  Position: ast.Position {}
+  1433  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1434  .  .  .  .  .  0: *ast.ExprStmt {
+  1435  .  .  .  .  .  .  Position: ast.Position {}
+  1436  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1437  .  .  .  .  .  .  .  Position: ast.Position {}
+  1438  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1439  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1440  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1441  .  .  .  .  .  .  .  .  .  Name: "console"
+  1442  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1443  .  .  .  .  .  .  .  .  }
+  1444  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1445  .  .  .  .  .  .  .  .  .  Name: "log"
+  1446  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1447  .  .  .  .  .  .  .  .  }
+  1448  .  .  .  .  .  .  .  }
+  1449  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1450  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1451  .  .  .  .  .  .  .  .  .  Name: "i"
+  1452  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1453  .  .  .  .  .  .  .  .  }
+  1454  .  .  .  .  .  .  .  }
+  1455  .  .  .  .  .  .  }
+  1456  .  .  .  .  .  }
+  1457  .  .  .  .  }
+  1458  .  .  .  }
+  1459  .  .  }
+  1460  .  }
+  1461  }

--- a/internal/testdata/expected/javascript/ir/functions.js.out
+++ b/internal/testdata/expected/javascript/ir/functions.js.out
@@ -4,6 +4,7 @@ file functions.js:
   func  f1  (a, b)
   func  f10 ()
   func  f11 ()
+  func  f12 ()
   func  f2  (a)
   func  f3  (a, b)
   func  f4  ()
@@ -12,6 +13,7 @@ file functions.js:
   func  f7  (b)
   func  f8  (a)
   func  f9  (a)
+  var   i  
 
 
 
@@ -60,6 +62,14 @@ func f11():
 	%t5 = hashmap[{"k": "v"}]
 	%t6 = hashmap[{"k": "v"}]
 	%t7 = array[%t5,%t6]
+
+# Name: f12
+# File: functions.js
+# Location: functions.js:97:0
+func f12():
+0:                                                                         entry
+	%t0 = array["1","2","3"]
+	%t1 = console.log(%t0)
 
 # Name: f2
 # File: functions.js
@@ -139,7 +149,8 @@ func f7(b):
 	%t2 = "y"
 	%t3 = "x"
 	%t4 = "x"
-	%t5 = b
+	%t5 = "x"
+	%t6 = b
 
 # Name: f8
 # File: functions.js

--- a/internal/testdata/source/javascript/functions.js
+++ b/internal/testdata/source/javascript/functions.js
@@ -91,3 +91,9 @@ function f11() {
 	let d = { 'k': 'v', 'k2': 'v2' }
 	let e = [{ 'k': 'v' }, { 'k': 'v' }]
 }
+
+const i = [1,2,3]
+
+function f12() {
+	console.log(i)
+}


### PR DESCRIPTION
Previously when using global values in functions, the value
was not being parsed. This commit changes this behavior to check and
parse the value of the global variable and add to the function's locals.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
