### PR TITLE
ir:feat - add support for for loop

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -204,6 +204,7 @@ type (
 	// IncExpr node represents a variable increment expression
 	IncExpr struct {
 		Position
+		Op  string // Operator. // TODO: This should be a concrete type.
 		Arg *Ident // identifier of the argument being incremented
 	}
 )
@@ -314,7 +315,7 @@ type (
 	ForStatement struct {
 		Position
 		VarDecl   Stmt       // For initializer
-		Cond      Stmt       // Condition needed to match
+		Cond      Expr       // Condition needed to match
 		Increment Expr       // For Increment expression
 		Body      *BlockStmt // For body
 	}
@@ -435,4 +436,9 @@ func NewIdent(node *cst.Node) *Ident {
 // IsNosec return true if the given slice of bytes contains nosec directive.
 func IsNosec(s []byte) bool {
 	return bytes.Contains(s, nosec)
+}
+
+func (n *BadNode) String() string {
+	pos := n.Pos().start
+	return fmt.Sprintf("%s %d:%d", n.Comment, pos.Row, pos.Column)
 }

--- a/internal/horusec-javascript/ast.go
+++ b/internal/horusec-javascript/ast.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:funlen,gocyclo // We need a lot of lines and if to parse CST to AST
+// nolint:funlen,gocyclo,gocognit // We need a lot of lines and if's to parse CST to AST
 package javascript
 
 import (
@@ -437,11 +437,16 @@ func (p *parser) parseStmt(node *cst.Node) ast.Stmt {
 
 		return stmt
 	case ForStatement:
+		var incExpr ast.Expr
+		if inc := node.ChildByFieldName("increment"); inc != nil {
+			incExpr = p.parseExpr(inc)
+		}
+
 		return &ast.ForStatement{
 			Position:  ast.NewPosition(node),
 			VarDecl:   p.parseStmt(node.ChildByFieldName("initializer")),
-			Cond:      p.parseStmt(node.ChildByFieldName("condition")),
-			Increment: p.parseExpr(node.ChildByFieldName("increment")),
+			Cond:      p.parseExpr(node.ChildByFieldName("condition")),
+			Increment: incExpr,
 			Body:      p.parseFuncBody(node.ChildByFieldName("body")),
 		}
 	case ForInStatement:
@@ -479,7 +484,7 @@ func (p *parser) parseStmt(node *cst.Node) ast.Stmt {
 		stmt.Body = body
 
 		return stmt
-	case ExportStatement:
+	case ExportStatement, EmptyStatement:
 		// Since export statements will not be very useful information in our ast for now,
 		// we will ignore this statement.
 		return nil
@@ -631,8 +636,12 @@ func (p *parser) parseExpr(node *cst.Node) ast.Expr {
 		return p.parseExpr(node.NamedChild(0))
 	case UpdateExpression:
 		return &ast.IncExpr{
-			Arg: ast.NewIdent(node.ChildByFieldName("argument")),
+			Position: ast.NewPosition(node),
+			Op:       node.ChildByFieldName("operator").Type(), // Type will return the operador cleaned.
+			Arg:      ast.NewIdent(node.ChildByFieldName("argument")),
 		}
+	case EmptyStatement:
+		return nil
 	default:
 		return ast.NewUnsupportedNode(node)
 	}

--- a/internal/horusec-javascript/node_types.go
+++ b/internal/horusec-javascript/node_types.go
@@ -85,6 +85,7 @@ const (
 	StatementIdentifier = "statement_identifier"
 	LabeledStatement    = "labeled_statement"
 	ExportStatement     = "export_statement"
+	EmptyStatement      = "empty_statement"
 
 	// ------------------------------------------------
 	//

--- a/internal/testdata/expected/javascript/ast/expressions.js.out
+++ b/internal/testdata/expected/javascript/ast/expressions.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "expressions.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 2) {
+     6  .  Decls: []ast.Decl (len = 3) {
      7  .  .  0: *ast.ImportDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -35,184 +35,249 @@
     34  .  .  .  .  }
     35  .  .  .  }
     36  .  .  }
-    37  .  }
-    38  .  Exprs: []ast.Expr (len = 3) {
-    39  .  .  0: *ast.CallExpr {
-    40  .  .  .  Position: ast.Position {}
-    41  .  .  .  Fun: *ast.SelectorExpr {
-    42  .  .  .  .  Position: ast.Position {}
-    43  .  .  .  .  Expr: *ast.Ident {
-    44  .  .  .  .  .  Name: "console"
-    45  .  .  .  .  .  Position: ast.Position {}
-    46  .  .  .  .  }
-    47  .  .  .  .  Sel: *ast.Ident {
-    48  .  .  .  .  .  Name: "log"
-    49  .  .  .  .  .  Position: ast.Position {}
-    50  .  .  .  .  }
-    51  .  .  .  }
-    52  .  .  .  Args: []ast.Expr (len = 1) {
-    53  .  .  .  .  0: *ast.BasicLit {
-    54  .  .  .  .  .  Position: ast.Position {}
-    55  .  .  .  .  .  Kind: "string"
-    56  .  .  .  .  .  Value: "testing"
-    57  .  .  .  .  }
-    58  .  .  .  }
-    59  .  .  }
-    60  .  .  1: *ast.CallExpr {
-    61  .  .  .  Position: ast.Position {}
-    62  .  .  .  Fun: *ast.SelectorExpr {
-    63  .  .  .  .  Position: ast.Position {}
-    64  .  .  .  .  Expr: *ast.Ident {
-    65  .  .  .  .  .  Name: "app"
-    66  .  .  .  .  .  Position: ast.Position {}
-    67  .  .  .  .  }
-    68  .  .  .  .  Sel: *ast.Ident {
-    69  .  .  .  .  .  Name: "get"
-    70  .  .  .  .  .  Position: ast.Position {}
-    71  .  .  .  .  }
-    72  .  .  .  }
-    73  .  .  .  Args: []ast.Expr (len = 2) {
-    74  .  .  .  .  0: *ast.BasicLit {
-    75  .  .  .  .  .  Position: ast.Position {}
-    76  .  .  .  .  .  Kind: "string"
-    77  .  .  .  .  .  Value: "/"
-    78  .  .  .  .  }
-    79  .  .  .  .  1: *ast.FuncLit {
-    80  .  .  .  .  .  Position: ast.Position {}
-    81  .  .  .  .  .  Type: *ast.FuncType {
-    82  .  .  .  .  .  .  Position: ast.Position {}
-    83  .  .  .  .  .  .  Params: *ast.FieldList {
-    84  .  .  .  .  .  .  .  Position: ast.Position {}
-    85  .  .  .  .  .  .  .  List: []*ast.Field (len = 2) {
-    86  .  .  .  .  .  .  .  .  0: *ast.Field {
-    87  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-    88  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
-    89  .  .  .  .  .  .  .  .  .  .  Name: "req"
-    90  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-    91  .  .  .  .  .  .  .  .  .  }
-    92  .  .  .  .  .  .  .  .  }
-    93  .  .  .  .  .  .  .  .  1: *ast.Field {
-    94  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-    95  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
-    96  .  .  .  .  .  .  .  .  .  .  Name: "res"
-    97  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-    98  .  .  .  .  .  .  .  .  .  }
-    99  .  .  .  .  .  .  .  .  }
-   100  .  .  .  .  .  .  .  }
-   101  .  .  .  .  .  .  }
-   102  .  .  .  .  .  }
-   103  .  .  .  .  .  Body: *ast.BlockStmt {
-   104  .  .  .  .  .  .  Position: ast.Position {}
-   105  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-   106  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-   107  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   108  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-   109  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   110  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-   111  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   112  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-   113  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-   114  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   115  .  .  .  .  .  .  .  .  .  .  }
-   116  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-   117  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-   118  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   119  .  .  .  .  .  .  .  .  .  .  }
-   120  .  .  .  .  .  .  .  .  .  }
-   121  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 2) {
-   122  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-   123  .  .  .  .  .  .  .  .  .  .  .  Name: "req"
-   124  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   125  .  .  .  .  .  .  .  .  .  .  }
-   126  .  .  .  .  .  .  .  .  .  .  1: *ast.Ident {
-   127  .  .  .  .  .  .  .  .  .  .  .  Name: "res"
-   128  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   129  .  .  .  .  .  .  .  .  .  .  }
-   130  .  .  .  .  .  .  .  .  .  }
-   131  .  .  .  .  .  .  .  .  }
-   132  .  .  .  .  .  .  .  }
-   133  .  .  .  .  .  .  }
-   134  .  .  .  .  .  }
-   135  .  .  .  .  }
-   136  .  .  .  }
-   137  .  .  }
-   138  .  .  2: *ast.CallExpr {
-   139  .  .  .  Position: ast.Position {}
-   140  .  .  .  Fun: *ast.SelectorExpr {
-   141  .  .  .  .  Position: ast.Position {}
-   142  .  .  .  .  Expr: *ast.Ident {
-   143  .  .  .  .  .  Name: "app"
-   144  .  .  .  .  .  Position: ast.Position {}
-   145  .  .  .  .  }
-   146  .  .  .  .  Sel: *ast.Ident {
-   147  .  .  .  .  .  Name: "set"
-   148  .  .  .  .  .  Position: ast.Position {}
-   149  .  .  .  .  }
-   150  .  .  .  }
-   151  .  .  .  Args: []ast.Expr (len = 2) {
-   152  .  .  .  .  0: *ast.BasicLit {
-   153  .  .  .  .  .  Position: ast.Position {}
-   154  .  .  .  .  .  Kind: "string"
-   155  .  .  .  .  .  Value: "/"
-   156  .  .  .  .  }
-   157  .  .  .  .  1: *ast.FuncLit {
-   158  .  .  .  .  .  Position: ast.Position {}
-   159  .  .  .  .  .  Type: *ast.FuncType {
-   160  .  .  .  .  .  .  Position: ast.Position {}
-   161  .  .  .  .  .  .  Params: *ast.FieldList {
-   162  .  .  .  .  .  .  .  Position: ast.Position {}
-   163  .  .  .  .  .  .  .  List: []*ast.Field (len = 2) {
-   164  .  .  .  .  .  .  .  .  0: *ast.Field {
-   165  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   166  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
-   167  .  .  .  .  .  .  .  .  .  .  Name: "req"
-   168  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   169  .  .  .  .  .  .  .  .  .  }
-   170  .  .  .  .  .  .  .  .  }
-   171  .  .  .  .  .  .  .  .  1: *ast.Field {
-   172  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   173  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
-   174  .  .  .  .  .  .  .  .  .  .  Name: "res"
-   175  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   176  .  .  .  .  .  .  .  .  .  }
-   177  .  .  .  .  .  .  .  .  }
-   178  .  .  .  .  .  .  .  }
-   179  .  .  .  .  .  .  }
-   180  .  .  .  .  .  }
-   181  .  .  .  .  .  Body: *ast.BlockStmt {
-   182  .  .  .  .  .  .  Position: ast.Position {}
-   183  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-   184  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-   185  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   186  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-   187  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   188  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-   189  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   190  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-   191  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-   192  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   193  .  .  .  .  .  .  .  .  .  .  }
-   194  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-   195  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-   196  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   197  .  .  .  .  .  .  .  .  .  .  }
-   198  .  .  .  .  .  .  .  .  .  }
-   199  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 2) {
-   200  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-   201  .  .  .  .  .  .  .  .  .  .  .  Name: "req"
-   202  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   203  .  .  .  .  .  .  .  .  .  .  }
-   204  .  .  .  .  .  .  .  .  .  .  1: *ast.Ident {
-   205  .  .  .  .  .  .  .  .  .  .  .  Name: "res"
-   206  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   207  .  .  .  .  .  .  .  .  .  .  }
-   208  .  .  .  .  .  .  .  .  .  }
-   209  .  .  .  .  .  .  .  .  }
-   210  .  .  .  .  .  .  .  }
-   211  .  .  .  .  .  .  }
-   212  .  .  .  .  .  }
-   213  .  .  .  .  }
-   214  .  .  .  }
-   215  .  .  }
-   216  .  }
-   217  }
+    37  .  .  2: *ast.FuncDecl {
+    38  .  .  .  Position: ast.Position {}
+    39  .  .  .  Name: *ast.Ident {
+    40  .  .  .  .  Name: "incrementExpr"
+    41  .  .  .  .  Position: ast.Position {}
+    42  .  .  .  }
+    43  .  .  .  Type: *ast.FuncType {
+    44  .  .  .  .  Position: ast.Position {}
+    45  .  .  .  .  Params: *ast.FieldList {
+    46  .  .  .  .  .  Position: ast.Position {}
+    47  .  .  .  .  }
+    48  .  .  .  }
+    49  .  .  .  Body: *ast.BlockStmt {
+    50  .  .  .  .  Position: ast.Position {}
+    51  .  .  .  .  List: []ast.Stmt (len = 4) {
+    52  .  .  .  .  .  0: *ast.AssignStmt {
+    53  .  .  .  .  .  .  Position: ast.Position {}
+    54  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+    55  .  .  .  .  .  .  .  0: *ast.Ident {
+    56  .  .  .  .  .  .  .  .  Name: "a"
+    57  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    58  .  .  .  .  .  .  .  }
+    59  .  .  .  .  .  .  }
+    60  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+    61  .  .  .  .  .  .  .  0: *ast.BasicLit {
+    62  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    63  .  .  .  .  .  .  .  .  Kind: "number"
+    64  .  .  .  .  .  .  .  .  Value: "0"
+    65  .  .  .  .  .  .  .  }
+    66  .  .  .  .  .  .  }
+    67  .  .  .  .  .  }
+    68  .  .  .  .  .  1: *ast.ExprStmt {
+    69  .  .  .  .  .  .  Position: ast.Position {}
+    70  .  .  .  .  .  .  Expr: *ast.IncExpr {
+    71  .  .  .  .  .  .  .  Position: ast.Position {}
+    72  .  .  .  .  .  .  .  Op: "++"
+    73  .  .  .  .  .  .  .  Arg: *ast.Ident {
+    74  .  .  .  .  .  .  .  .  Name: "a"
+    75  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    76  .  .  .  .  .  .  .  }
+    77  .  .  .  .  .  .  }
+    78  .  .  .  .  .  }
+    79  .  .  .  .  .  2: *ast.ExprStmt {
+    80  .  .  .  .  .  .  Position: ast.Position {}
+    81  .  .  .  .  .  .  Expr: *ast.IncExpr {
+    82  .  .  .  .  .  .  .  Position: ast.Position {}
+    83  .  .  .  .  .  .  .  Op: "--"
+    84  .  .  .  .  .  .  .  Arg: *ast.Ident {
+    85  .  .  .  .  .  .  .  .  Name: "a"
+    86  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    87  .  .  .  .  .  .  .  }
+    88  .  .  .  .  .  .  }
+    89  .  .  .  .  .  }
+    90  .  .  .  .  .  3: *ast.ReturnStmt {
+    91  .  .  .  .  .  .  Position: ast.Position {}
+    92  .  .  .  .  .  .  Results: []ast.Expr (len = 1) {
+    93  .  .  .  .  .  .  .  0: *ast.Ident {
+    94  .  .  .  .  .  .  .  .  Name: "a"
+    95  .  .  .  .  .  .  .  .  Position: ast.Position {}
+    96  .  .  .  .  .  .  .  }
+    97  .  .  .  .  .  .  }
+    98  .  .  .  .  .  }
+    99  .  .  .  .  }
+   100  .  .  .  }
+   101  .  .  }
+   102  .  }
+   103  .  Exprs: []ast.Expr (len = 3) {
+   104  .  .  0: *ast.CallExpr {
+   105  .  .  .  Position: ast.Position {}
+   106  .  .  .  Fun: *ast.SelectorExpr {
+   107  .  .  .  .  Position: ast.Position {}
+   108  .  .  .  .  Expr: *ast.Ident {
+   109  .  .  .  .  .  Name: "console"
+   110  .  .  .  .  .  Position: ast.Position {}
+   111  .  .  .  .  }
+   112  .  .  .  .  Sel: *ast.Ident {
+   113  .  .  .  .  .  Name: "log"
+   114  .  .  .  .  .  Position: ast.Position {}
+   115  .  .  .  .  }
+   116  .  .  .  }
+   117  .  .  .  Args: []ast.Expr (len = 1) {
+   118  .  .  .  .  0: *ast.BasicLit {
+   119  .  .  .  .  .  Position: ast.Position {}
+   120  .  .  .  .  .  Kind: "string"
+   121  .  .  .  .  .  Value: "testing"
+   122  .  .  .  .  }
+   123  .  .  .  }
+   124  .  .  }
+   125  .  .  1: *ast.CallExpr {
+   126  .  .  .  Position: ast.Position {}
+   127  .  .  .  Fun: *ast.SelectorExpr {
+   128  .  .  .  .  Position: ast.Position {}
+   129  .  .  .  .  Expr: *ast.Ident {
+   130  .  .  .  .  .  Name: "app"
+   131  .  .  .  .  .  Position: ast.Position {}
+   132  .  .  .  .  }
+   133  .  .  .  .  Sel: *ast.Ident {
+   134  .  .  .  .  .  Name: "get"
+   135  .  .  .  .  .  Position: ast.Position {}
+   136  .  .  .  .  }
+   137  .  .  .  }
+   138  .  .  .  Args: []ast.Expr (len = 2) {
+   139  .  .  .  .  0: *ast.BasicLit {
+   140  .  .  .  .  .  Position: ast.Position {}
+   141  .  .  .  .  .  Kind: "string"
+   142  .  .  .  .  .  Value: "/"
+   143  .  .  .  .  }
+   144  .  .  .  .  1: *ast.FuncLit {
+   145  .  .  .  .  .  Position: ast.Position {}
+   146  .  .  .  .  .  Type: *ast.FuncType {
+   147  .  .  .  .  .  .  Position: ast.Position {}
+   148  .  .  .  .  .  .  Params: *ast.FieldList {
+   149  .  .  .  .  .  .  .  Position: ast.Position {}
+   150  .  .  .  .  .  .  .  List: []*ast.Field (len = 2) {
+   151  .  .  .  .  .  .  .  .  0: *ast.Field {
+   152  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   153  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
+   154  .  .  .  .  .  .  .  .  .  .  Name: "req"
+   155  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   156  .  .  .  .  .  .  .  .  .  }
+   157  .  .  .  .  .  .  .  .  }
+   158  .  .  .  .  .  .  .  .  1: *ast.Field {
+   159  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   160  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
+   161  .  .  .  .  .  .  .  .  .  .  Name: "res"
+   162  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   163  .  .  .  .  .  .  .  .  .  }
+   164  .  .  .  .  .  .  .  .  }
+   165  .  .  .  .  .  .  .  }
+   166  .  .  .  .  .  .  }
+   167  .  .  .  .  .  }
+   168  .  .  .  .  .  Body: *ast.BlockStmt {
+   169  .  .  .  .  .  .  Position: ast.Position {}
+   170  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+   171  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+   172  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   173  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   174  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   175  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   176  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   177  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   178  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+   179  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   180  .  .  .  .  .  .  .  .  .  .  }
+   181  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   182  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+   183  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   184  .  .  .  .  .  .  .  .  .  .  }
+   185  .  .  .  .  .  .  .  .  .  }
+   186  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 2) {
+   187  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+   188  .  .  .  .  .  .  .  .  .  .  .  Name: "req"
+   189  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   190  .  .  .  .  .  .  .  .  .  .  }
+   191  .  .  .  .  .  .  .  .  .  .  1: *ast.Ident {
+   192  .  .  .  .  .  .  .  .  .  .  .  Name: "res"
+   193  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   194  .  .  .  .  .  .  .  .  .  .  }
+   195  .  .  .  .  .  .  .  .  .  }
+   196  .  .  .  .  .  .  .  .  }
+   197  .  .  .  .  .  .  .  }
+   198  .  .  .  .  .  .  }
+   199  .  .  .  .  .  }
+   200  .  .  .  .  }
+   201  .  .  .  }
+   202  .  .  }
+   203  .  .  2: *ast.CallExpr {
+   204  .  .  .  Position: ast.Position {}
+   205  .  .  .  Fun: *ast.SelectorExpr {
+   206  .  .  .  .  Position: ast.Position {}
+   207  .  .  .  .  Expr: *ast.Ident {
+   208  .  .  .  .  .  Name: "app"
+   209  .  .  .  .  .  Position: ast.Position {}
+   210  .  .  .  .  }
+   211  .  .  .  .  Sel: *ast.Ident {
+   212  .  .  .  .  .  Name: "set"
+   213  .  .  .  .  .  Position: ast.Position {}
+   214  .  .  .  .  }
+   215  .  .  .  }
+   216  .  .  .  Args: []ast.Expr (len = 2) {
+   217  .  .  .  .  0: *ast.BasicLit {
+   218  .  .  .  .  .  Position: ast.Position {}
+   219  .  .  .  .  .  Kind: "string"
+   220  .  .  .  .  .  Value: "/"
+   221  .  .  .  .  }
+   222  .  .  .  .  1: *ast.FuncLit {
+   223  .  .  .  .  .  Position: ast.Position {}
+   224  .  .  .  .  .  Type: *ast.FuncType {
+   225  .  .  .  .  .  .  Position: ast.Position {}
+   226  .  .  .  .  .  .  Params: *ast.FieldList {
+   227  .  .  .  .  .  .  .  Position: ast.Position {}
+   228  .  .  .  .  .  .  .  List: []*ast.Field (len = 2) {
+   229  .  .  .  .  .  .  .  .  0: *ast.Field {
+   230  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   231  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
+   232  .  .  .  .  .  .  .  .  .  .  Name: "req"
+   233  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   234  .  .  .  .  .  .  .  .  .  }
+   235  .  .  .  .  .  .  .  .  }
+   236  .  .  .  .  .  .  .  .  1: *ast.Field {
+   237  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   238  .  .  .  .  .  .  .  .  .  Name: *ast.Ident {
+   239  .  .  .  .  .  .  .  .  .  .  Name: "res"
+   240  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   241  .  .  .  .  .  .  .  .  .  }
+   242  .  .  .  .  .  .  .  .  }
+   243  .  .  .  .  .  .  .  }
+   244  .  .  .  .  .  .  }
+   245  .  .  .  .  .  }
+   246  .  .  .  .  .  Body: *ast.BlockStmt {
+   247  .  .  .  .  .  .  Position: ast.Position {}
+   248  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+   249  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+   250  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   251  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   252  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   253  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   254  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   255  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   256  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+   257  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   258  .  .  .  .  .  .  .  .  .  .  }
+   259  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   260  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+   261  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   262  .  .  .  .  .  .  .  .  .  .  }
+   263  .  .  .  .  .  .  .  .  .  }
+   264  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 2) {
+   265  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+   266  .  .  .  .  .  .  .  .  .  .  .  Name: "req"
+   267  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   268  .  .  .  .  .  .  .  .  .  .  }
+   269  .  .  .  .  .  .  .  .  .  .  1: *ast.Ident {
+   270  .  .  .  .  .  .  .  .  .  .  .  Name: "res"
+   271  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   272  .  .  .  .  .  .  .  .  .  .  }
+   273  .  .  .  .  .  .  .  .  .  }
+   274  .  .  .  .  .  .  .  .  }
+   275  .  .  .  .  .  .  .  }
+   276  .  .  .  .  .  .  }
+   277  .  .  .  .  .  }
+   278  .  .  .  .  }
+   279  .  .  .  }
+   280  .  .  }
+   281  .  }
+   282  }

--- a/internal/testdata/expected/javascript/ast/statements.js.out
+++ b/internal/testdata/expected/javascript/ast/statements.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "statements.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 7) {
+     6  .  Decls: []ast.Decl (len = 11) {
      7  .  .  0: *ast.FuncDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -903,168 +903,439 @@
    902  .  .  .  .  .  .  .  .  }
    903  .  .  .  .  .  .  .  }
    904  .  .  .  .  .  .  }
-   905  .  .  .  .  .  .  Cond: *ast.ExprStmt {
+   905  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
    906  .  .  .  .  .  .  .  Position: ast.Position {}
-   907  .  .  .  .  .  .  .  Expr: *ast.BinaryExpr {
-   908  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   909  .  .  .  .  .  .  .  .  Left: *ast.Ident {
-   910  .  .  .  .  .  .  .  .  .  Name: "i"
-   911  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   912  .  .  .  .  .  .  .  .  }
-   913  .  .  .  .  .  .  .  .  Op: "<"
-   914  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
-   915  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   916  .  .  .  .  .  .  .  .  .  Kind: "number"
-   917  .  .  .  .  .  .  .  .  .  Value: "9"
-   918  .  .  .  .  .  .  .  .  }
-   919  .  .  .  .  .  .  .  }
-   920  .  .  .  .  .  .  }
-   921  .  .  .  .  .  .  Increment: *ast.IncExpr {
-   922  .  .  .  .  .  .  .  Position: ast.Position {}
-   923  .  .  .  .  .  .  .  Arg: *ast.Ident {
-   924  .  .  .  .  .  .  .  .  Name: "i"
-   925  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   926  .  .  .  .  .  .  .  }
-   927  .  .  .  .  .  .  }
-   928  .  .  .  .  .  .  Body: *ast.BlockStmt {
-   929  .  .  .  .  .  .  .  Position: ast.Position {}
-   930  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-   931  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-   932  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   933  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-   934  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   935  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-   936  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   937  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-   938  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-   939  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   940  .  .  .  .  .  .  .  .  .  .  .  }
-   941  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-   942  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-   943  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   944  .  .  .  .  .  .  .  .  .  .  .  }
-   945  .  .  .  .  .  .  .  .  .  .  }
-   946  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-   947  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-   948  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
-   949  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   950  .  .  .  .  .  .  .  .  .  .  .  }
-   951  .  .  .  .  .  .  .  .  .  .  }
-   952  .  .  .  .  .  .  .  .  .  }
-   953  .  .  .  .  .  .  .  .  }
-   954  .  .  .  .  .  .  .  }
-   955  .  .  .  .  .  .  }
-   956  .  .  .  .  .  }
-   957  .  .  .  .  }
-   958  .  .  .  }
-   959  .  .  }
-   960  .  .  5: *ast.FuncDecl {
-   961  .  .  .  Position: ast.Position {}
-   962  .  .  .  Name: *ast.Ident {
-   963  .  .  .  .  Name: "ForInStatement"
-   964  .  .  .  .  Position: ast.Position {}
-   965  .  .  .  }
-   966  .  .  .  Type: *ast.FuncType {
-   967  .  .  .  .  Position: ast.Position {}
-   968  .  .  .  .  Params: *ast.FieldList {
-   969  .  .  .  .  .  Position: ast.Position {}
-   970  .  .  .  .  }
-   971  .  .  .  }
-   972  .  .  .  Body: *ast.BlockStmt {
-   973  .  .  .  .  Position: ast.Position {}
-   974  .  .  .  .  List: []ast.Stmt (len = 2) {
-   975  .  .  .  .  .  0: *ast.AssignStmt {
-   976  .  .  .  .  .  .  Position: ast.Position {}
-   977  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-   978  .  .  .  .  .  .  .  0: *ast.Ident {
-   979  .  .  .  .  .  .  .  .  Name: "values"
-   980  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   981  .  .  .  .  .  .  .  }
-   982  .  .  .  .  .  .  }
-   983  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-   984  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
-   985  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   986  .  .  .  .  .  .  .  .  Elts: []ast.Expr (len = 3) {
-   987  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-   988  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   989  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-   990  .  .  .  .  .  .  .  .  .  .  Value: "a"
-   991  .  .  .  .  .  .  .  .  .  }
-   992  .  .  .  .  .  .  .  .  .  1: *ast.BasicLit {
-   993  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   994  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-   995  .  .  .  .  .  .  .  .  .  .  Value: "b"
-   996  .  .  .  .  .  .  .  .  .  }
-   997  .  .  .  .  .  .  .  .  .  2: *ast.BasicLit {
-   998  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   999  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1000  .  .  .  .  .  .  .  .  .  .  Value: "c"
-  1001  .  .  .  .  .  .  .  .  .  }
-  1002  .  .  .  .  .  .  .  .  }
-  1003  .  .  .  .  .  .  .  .  Comment: "array"
-  1004  .  .  .  .  .  .  .  }
-  1005  .  .  .  .  .  .  }
-  1006  .  .  .  .  .  }
-  1007  .  .  .  .  .  1: *ast.ForInStatement {
-  1008  .  .  .  .  .  .  Position: ast.Position {}
-  1009  .  .  .  .  .  .  Left: *ast.Ident {
-  1010  .  .  .  .  .  .  .  Name: "value"
-  1011  .  .  .  .  .  .  .  Position: ast.Position {}
-  1012  .  .  .  .  .  .  }
-  1013  .  .  .  .  .  .  Right: *ast.Ident {
-  1014  .  .  .  .  .  .  .  Name: "values"
-  1015  .  .  .  .  .  .  .  Position: ast.Position {}
-  1016  .  .  .  .  .  .  }
-  1017  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1018  .  .  .  .  .  .  .  Position: ast.Position {}
-  1019  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  1020  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1021  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1022  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1023  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1024  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1025  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1026  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1027  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1028  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1029  .  .  .  .  .  .  .  .  .  .  .  }
-  1030  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1031  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1032  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1033  .  .  .  .  .  .  .  .  .  .  .  }
-  1034  .  .  .  .  .  .  .  .  .  .  }
-  1035  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1036  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  1037  .  .  .  .  .  .  .  .  .  .  .  .  Name: "value"
-  1038  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1039  .  .  .  .  .  .  .  .  .  .  .  }
-  1040  .  .  .  .  .  .  .  .  .  .  }
-  1041  .  .  .  .  .  .  .  .  .  }
-  1042  .  .  .  .  .  .  .  .  }
-  1043  .  .  .  .  .  .  .  }
-  1044  .  .  .  .  .  .  }
-  1045  .  .  .  .  .  }
-  1046  .  .  .  .  }
-  1047  .  .  .  }
-  1048  .  .  }
-  1049  .  .  6: *ast.FuncDecl {
-  1050  .  .  .  Position: ast.Position {}
-  1051  .  .  .  Name: *ast.Ident {
-  1052  .  .  .  .  Name: "ExportStatement"
-  1053  .  .  .  .  Position: ast.Position {}
-  1054  .  .  .  }
-  1055  .  .  .  Type: *ast.FuncType {
-  1056  .  .  .  .  Position: ast.Position {}
-  1057  .  .  .  .  Params: *ast.FieldList {
-  1058  .  .  .  .  .  Position: ast.Position {}
-  1059  .  .  .  .  }
-  1060  .  .  .  }
-  1061  .  .  .  Body: *ast.BlockStmt {
-  1062  .  .  .  .  Position: ast.Position {}
-  1063  .  .  .  .  List: []ast.Stmt (len = 1) {
-  1064  .  .  .  .  .  0: nil
+   907  .  .  .  .  .  .  .  Left: *ast.Ident {
+   908  .  .  .  .  .  .  .  .  Name: "i"
+   909  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   910  .  .  .  .  .  .  .  }
+   911  .  .  .  .  .  .  .  Op: "<"
+   912  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+   913  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   914  .  .  .  .  .  .  .  .  Kind: "number"
+   915  .  .  .  .  .  .  .  .  Value: "9"
+   916  .  .  .  .  .  .  .  }
+   917  .  .  .  .  .  .  }
+   918  .  .  .  .  .  .  Increment: *ast.IncExpr {
+   919  .  .  .  .  .  .  .  Position: ast.Position {}
+   920  .  .  .  .  .  .  .  Op: "++"
+   921  .  .  .  .  .  .  .  Arg: *ast.Ident {
+   922  .  .  .  .  .  .  .  .  Name: "i"
+   923  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   924  .  .  .  .  .  .  .  }
+   925  .  .  .  .  .  .  }
+   926  .  .  .  .  .  .  Body: *ast.BlockStmt {
+   927  .  .  .  .  .  .  .  Position: ast.Position {}
+   928  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+   929  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+   930  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   931  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   932  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   933  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   934  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   935  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   936  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+   937  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   938  .  .  .  .  .  .  .  .  .  .  .  }
+   939  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   940  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+   941  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   942  .  .  .  .  .  .  .  .  .  .  .  }
+   943  .  .  .  .  .  .  .  .  .  .  }
+   944  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   945  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+   946  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+   947  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   948  .  .  .  .  .  .  .  .  .  .  .  }
+   949  .  .  .  .  .  .  .  .  .  .  }
+   950  .  .  .  .  .  .  .  .  .  }
+   951  .  .  .  .  .  .  .  .  }
+   952  .  .  .  .  .  .  .  }
+   953  .  .  .  .  .  .  }
+   954  .  .  .  .  .  }
+   955  .  .  .  .  }
+   956  .  .  .  }
+   957  .  .  }
+   958  .  .  5: *ast.FuncDecl {
+   959  .  .  .  Position: ast.Position {}
+   960  .  .  .  Name: *ast.Ident {
+   961  .  .  .  .  Name: "ForStatementIteratingOverList"
+   962  .  .  .  .  Position: ast.Position {}
+   963  .  .  .  }
+   964  .  .  .  Type: *ast.FuncType {
+   965  .  .  .  .  Position: ast.Position {}
+   966  .  .  .  .  Params: *ast.FieldList {
+   967  .  .  .  .  .  Position: ast.Position {}
+   968  .  .  .  .  .  List: []*ast.Field (len = 1) {
+   969  .  .  .  .  .  .  0: *ast.Field {
+   970  .  .  .  .  .  .  .  Position: ast.Position {}
+   971  .  .  .  .  .  .  .  Name: *ast.Ident {
+   972  .  .  .  .  .  .  .  .  Name: "data"
+   973  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   974  .  .  .  .  .  .  .  }
+   975  .  .  .  .  .  .  }
+   976  .  .  .  .  .  }
+   977  .  .  .  .  }
+   978  .  .  .  }
+   979  .  .  .  Body: *ast.BlockStmt {
+   980  .  .  .  .  Position: ast.Position {}
+   981  .  .  .  .  List: []ast.Stmt (len = 3) {
+   982  .  .  .  .  .  0: *ast.AssignStmt {
+   983  .  .  .  .  .  .  Position: ast.Position {}
+   984  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+   985  .  .  .  .  .  .  .  0: *ast.Ident {
+   986  .  .  .  .  .  .  .  .  Name: "sum"
+   987  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   988  .  .  .  .  .  .  .  }
+   989  .  .  .  .  .  .  }
+   990  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+   991  .  .  .  .  .  .  .  0: *ast.BasicLit {
+   992  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   993  .  .  .  .  .  .  .  .  Kind: "number"
+   994  .  .  .  .  .  .  .  .  Value: "0"
+   995  .  .  .  .  .  .  .  }
+   996  .  .  .  .  .  .  }
+   997  .  .  .  .  .  }
+   998  .  .  .  .  .  1: *ast.ForStatement {
+   999  .  .  .  .  .  .  Position: ast.Position {}
+  1000  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1001  .  .  .  .  .  .  .  Position: ast.Position {}
+  1002  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1003  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1004  .  .  .  .  .  .  .  .  .  Name: "i"
+  1005  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1006  .  .  .  .  .  .  .  .  }
+  1007  .  .  .  .  .  .  .  }
+  1008  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1009  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1010  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1011  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1012  .  .  .  .  .  .  .  .  .  Value: "0"
+  1013  .  .  .  .  .  .  .  .  }
+  1014  .  .  .  .  .  .  .  }
+  1015  .  .  .  .  .  .  }
+  1016  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1017  .  .  .  .  .  .  .  Position: ast.Position {}
+  1018  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1019  .  .  .  .  .  .  .  .  Name: "i"
+  1020  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1021  .  .  .  .  .  .  .  }
+  1022  .  .  .  .  .  .  .  Op: "<"
+  1023  .  .  .  .  .  .  .  Right: *ast.SelectorExpr {
+  1024  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1025  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1026  .  .  .  .  .  .  .  .  .  Name: "data"
+  1027  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1028  .  .  .  .  .  .  .  .  }
+  1029  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1030  .  .  .  .  .  .  .  .  .  Name: "length"
+  1031  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1032  .  .  .  .  .  .  .  .  }
+  1033  .  .  .  .  .  .  .  }
+  1034  .  .  .  .  .  .  }
+  1035  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1036  .  .  .  .  .  .  .  Position: ast.Position {}
+  1037  .  .  .  .  .  .  .  Op: "++"
+  1038  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1039  .  .  .  .  .  .  .  .  Name: "i"
+  1040  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1041  .  .  .  .  .  .  .  }
+  1042  .  .  .  .  .  .  }
+  1043  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1044  .  .  .  .  .  .  .  Position: ast.Position {}
+  1045  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1046  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1047  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1048  .  .  .  .  .  .  .  .  .  Expr: *ast.BadNode {
+  1049  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1050  .  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <augmented_assignment_expression>"
+  1051  .  .  .  .  .  .  .  .  .  }
+  1052  .  .  .  .  .  .  .  .  }
+  1053  .  .  .  .  .  .  .  }
+  1054  .  .  .  .  .  .  }
+  1055  .  .  .  .  .  }
+  1056  .  .  .  .  .  2: *ast.ReturnStmt {
+  1057  .  .  .  .  .  .  Position: ast.Position {}
+  1058  .  .  .  .  .  .  Results: []ast.Expr (len = 1) {
+  1059  .  .  .  .  .  .  .  0: *ast.Ident {
+  1060  .  .  .  .  .  .  .  .  Name: "sum"
+  1061  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1062  .  .  .  .  .  .  .  }
+  1063  .  .  .  .  .  .  }
+  1064  .  .  .  .  .  }
   1065  .  .  .  .  }
   1066  .  .  .  }
   1067  .  .  }
-  1068  .  }
-  1069  }
+  1068  .  .  6: *ast.FuncDecl {
+  1069  .  .  .  Position: ast.Position {}
+  1070  .  .  .  Name: *ast.Ident {
+  1071  .  .  .  .  Name: "ForStatementWithoutBinaryExpressionIncremet"
+  1072  .  .  .  .  Position: ast.Position {}
+  1073  .  .  .  }
+  1074  .  .  .  Type: *ast.FuncType {
+  1075  .  .  .  .  Position: ast.Position {}
+  1076  .  .  .  .  Params: *ast.FieldList {
+  1077  .  .  .  .  .  Position: ast.Position {}
+  1078  .  .  .  .  }
+  1079  .  .  .  }
+  1080  .  .  .  Body: *ast.BlockStmt {
+  1081  .  .  .  .  Position: ast.Position {}
+  1082  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1083  .  .  .  .  .  0: *ast.ForStatement {
+  1084  .  .  .  .  .  .  Position: ast.Position {}
+  1085  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1086  .  .  .  .  .  .  .  Position: ast.Position {}
+  1087  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 2) {
+  1088  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1089  .  .  .  .  .  .  .  .  .  Name: "a"
+  1090  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1091  .  .  .  .  .  .  .  .  }
+  1092  .  .  .  .  .  .  .  .  1: *ast.Ident {
+  1093  .  .  .  .  .  .  .  .  .  Name: "b"
+  1094  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1095  .  .  .  .  .  .  .  .  }
+  1096  .  .  .  .  .  .  .  }
+  1097  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 0) {}
+  1098  .  .  .  .  .  .  }
+  1099  .  .  .  .  .  .  Cond: *ast.Ident {
+  1100  .  .  .  .  .  .  .  Name: "c"
+  1101  .  .  .  .  .  .  .  Position: ast.Position {}
+  1102  .  .  .  .  .  .  }
+  1103  .  .  .  .  .  .  Increment: *ast.Ident {
+  1104  .  .  .  .  .  .  .  Name: "d"
+  1105  .  .  .  .  .  .  .  Position: ast.Position {}
+  1106  .  .  .  .  .  .  }
+  1107  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1108  .  .  .  .  .  .  .  Position: ast.Position {}
+  1109  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1110  .  .  .  .  .  .  .  .  0: *ast.BadNode {
+  1111  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1112  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <identifier>"
+  1113  .  .  .  .  .  .  .  .  }
+  1114  .  .  .  .  .  .  .  }
+  1115  .  .  .  .  .  .  }
+  1116  .  .  .  .  .  }
+  1117  .  .  .  .  }
+  1118  .  .  .  }
+  1119  .  .  }
+  1120  .  .  7: *ast.FuncDecl {
+  1121  .  .  .  Position: ast.Position {}
+  1122  .  .  .  Name: *ast.Ident {
+  1123  .  .  .  .  Name: "ForStatementEndlessRecursion"
+  1124  .  .  .  .  Position: ast.Position {}
+  1125  .  .  .  }
+  1126  .  .  .  Type: *ast.FuncType {
+  1127  .  .  .  .  Position: ast.Position {}
+  1128  .  .  .  .  Params: *ast.FieldList {
+  1129  .  .  .  .  .  Position: ast.Position {}
+  1130  .  .  .  .  }
+  1131  .  .  .  }
+  1132  .  .  .  Body: *ast.BlockStmt {
+  1133  .  .  .  .  Position: ast.Position {}
+  1134  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1135  .  .  .  .  .  0: *ast.ForStatement {
+  1136  .  .  .  .  .  .  Position: ast.Position {}
+  1137  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1138  .  .  .  .  .  .  .  Position: ast.Position {}
+  1139  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1140  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1141  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1142  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1143  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1144  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1145  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1146  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1147  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1148  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1149  .  .  .  .  .  .  .  .  .  .  .  }
+  1150  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1151  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1152  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1153  .  .  .  .  .  .  .  .  .  .  .  }
+  1154  .  .  .  .  .  .  .  .  .  .  }
+  1155  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1156  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1157  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1158  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1159  .  .  .  .  .  .  .  .  .  .  .  .  Value: "endless recursion"
+  1160  .  .  .  .  .  .  .  .  .  .  .  }
+  1161  .  .  .  .  .  .  .  .  .  .  }
+  1162  .  .  .  .  .  .  .  .  .  }
+  1163  .  .  .  .  .  .  .  .  }
+  1164  .  .  .  .  .  .  .  }
+  1165  .  .  .  .  .  .  }
+  1166  .  .  .  .  .  }
+  1167  .  .  .  .  }
+  1168  .  .  .  }
+  1169  .  .  }
+  1170  .  .  8: *ast.FuncDecl {
+  1171  .  .  .  Position: ast.Position {}
+  1172  .  .  .  Name: *ast.Ident {
+  1173  .  .  .  .  Name: "ForStatementEmptyBody"
+  1174  .  .  .  .  Position: ast.Position {}
+  1175  .  .  .  }
+  1176  .  .  .  Type: *ast.FuncType {
+  1177  .  .  .  .  Position: ast.Position {}
+  1178  .  .  .  .  Params: *ast.FieldList {
+  1179  .  .  .  .  .  Position: ast.Position {}
+  1180  .  .  .  .  }
+  1181  .  .  .  }
+  1182  .  .  .  Body: *ast.BlockStmt {
+  1183  .  .  .  .  Position: ast.Position {}
+  1184  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1185  .  .  .  .  .  0: *ast.ForStatement {
+  1186  .  .  .  .  .  .  Position: ast.Position {}
+  1187  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1188  .  .  .  .  .  .  .  Position: ast.Position {}
+  1189  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1190  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1191  .  .  .  .  .  .  .  .  .  Name: "i"
+  1192  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1193  .  .  .  .  .  .  .  .  }
+  1194  .  .  .  .  .  .  .  }
+  1195  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1196  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1197  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1198  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1199  .  .  .  .  .  .  .  .  .  Value: "0"
+  1200  .  .  .  .  .  .  .  .  }
+  1201  .  .  .  .  .  .  .  }
+  1202  .  .  .  .  .  .  }
+  1203  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1204  .  .  .  .  .  .  .  Position: ast.Position {}
+  1205  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1206  .  .  .  .  .  .  .  .  Name: "i"
+  1207  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1208  .  .  .  .  .  .  .  }
+  1209  .  .  .  .  .  .  .  Op: "<"
+  1210  .  .  .  .  .  .  .  Right: *ast.Ident {
+  1211  .  .  .  .  .  .  .  .  Name: "l"
+  1212  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1213  .  .  .  .  .  .  .  }
+  1214  .  .  .  .  .  .  }
+  1215  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1216  .  .  .  .  .  .  .  Position: ast.Position {}
+  1217  .  .  .  .  .  .  .  Op: "++"
+  1218  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1219  .  .  .  .  .  .  .  .  Name: "i"
+  1220  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1221  .  .  .  .  .  .  .  }
+  1222  .  .  .  .  .  .  }
+  1223  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1224  .  .  .  .  .  .  .  Position: ast.Position {}
+  1225  .  .  .  .  .  .  .  List: []ast.Stmt (len = 0) {}
+  1226  .  .  .  .  .  .  }
+  1227  .  .  .  .  .  }
+  1228  .  .  .  .  }
+  1229  .  .  .  }
+  1230  .  .  }
+  1231  .  .  9: *ast.FuncDecl {
+  1232  .  .  .  Position: ast.Position {}
+  1233  .  .  .  Name: *ast.Ident {
+  1234  .  .  .  .  Name: "ForInStatement"
+  1235  .  .  .  .  Position: ast.Position {}
+  1236  .  .  .  }
+  1237  .  .  .  Type: *ast.FuncType {
+  1238  .  .  .  .  Position: ast.Position {}
+  1239  .  .  .  .  Params: *ast.FieldList {
+  1240  .  .  .  .  .  Position: ast.Position {}
+  1241  .  .  .  .  }
+  1242  .  .  .  }
+  1243  .  .  .  Body: *ast.BlockStmt {
+  1244  .  .  .  .  Position: ast.Position {}
+  1245  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1246  .  .  .  .  .  0: *ast.AssignStmt {
+  1247  .  .  .  .  .  .  Position: ast.Position {}
+  1248  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1249  .  .  .  .  .  .  .  0: *ast.Ident {
+  1250  .  .  .  .  .  .  .  .  Name: "values"
+  1251  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1252  .  .  .  .  .  .  .  }
+  1253  .  .  .  .  .  .  }
+  1254  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1255  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
+  1256  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1257  .  .  .  .  .  .  .  .  Elts: []ast.Expr (len = 3) {
+  1258  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1259  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1260  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1261  .  .  .  .  .  .  .  .  .  .  Value: "a"
+  1262  .  .  .  .  .  .  .  .  .  }
+  1263  .  .  .  .  .  .  .  .  .  1: *ast.BasicLit {
+  1264  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1265  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1266  .  .  .  .  .  .  .  .  .  .  Value: "b"
+  1267  .  .  .  .  .  .  .  .  .  }
+  1268  .  .  .  .  .  .  .  .  .  2: *ast.BasicLit {
+  1269  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1270  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1271  .  .  .  .  .  .  .  .  .  .  Value: "c"
+  1272  .  .  .  .  .  .  .  .  .  }
+  1273  .  .  .  .  .  .  .  .  }
+  1274  .  .  .  .  .  .  .  .  Comment: "array"
+  1275  .  .  .  .  .  .  .  }
+  1276  .  .  .  .  .  .  }
+  1277  .  .  .  .  .  }
+  1278  .  .  .  .  .  1: *ast.ForInStatement {
+  1279  .  .  .  .  .  .  Position: ast.Position {}
+  1280  .  .  .  .  .  .  Left: *ast.Ident {
+  1281  .  .  .  .  .  .  .  Name: "value"
+  1282  .  .  .  .  .  .  .  Position: ast.Position {}
+  1283  .  .  .  .  .  .  }
+  1284  .  .  .  .  .  .  Right: *ast.Ident {
+  1285  .  .  .  .  .  .  .  Name: "values"
+  1286  .  .  .  .  .  .  .  Position: ast.Position {}
+  1287  .  .  .  .  .  .  }
+  1288  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1289  .  .  .  .  .  .  .  Position: ast.Position {}
+  1290  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1291  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1292  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1293  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1294  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1295  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1296  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1297  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1298  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1299  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1300  .  .  .  .  .  .  .  .  .  .  .  }
+  1301  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1302  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1303  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1304  .  .  .  .  .  .  .  .  .  .  .  }
+  1305  .  .  .  .  .  .  .  .  .  .  }
+  1306  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1307  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1308  .  .  .  .  .  .  .  .  .  .  .  .  Name: "value"
+  1309  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1310  .  .  .  .  .  .  .  .  .  .  .  }
+  1311  .  .  .  .  .  .  .  .  .  .  }
+  1312  .  .  .  .  .  .  .  .  .  }
+  1313  .  .  .  .  .  .  .  .  }
+  1314  .  .  .  .  .  .  .  }
+  1315  .  .  .  .  .  .  }
+  1316  .  .  .  .  .  }
+  1317  .  .  .  .  }
+  1318  .  .  .  }
+  1319  .  .  }
+  1320  .  .  10: *ast.FuncDecl {
+  1321  .  .  .  Position: ast.Position {}
+  1322  .  .  .  Name: *ast.Ident {
+  1323  .  .  .  .  Name: "ExportStatement"
+  1324  .  .  .  .  Position: ast.Position {}
+  1325  .  .  .  }
+  1326  .  .  .  Type: *ast.FuncType {
+  1327  .  .  .  .  Position: ast.Position {}
+  1328  .  .  .  .  Params: *ast.FieldList {
+  1329  .  .  .  .  .  Position: ast.Position {}
+  1330  .  .  .  .  }
+  1331  .  .  .  }
+  1332  .  .  .  Body: *ast.BlockStmt {
+  1333  .  .  .  .  Position: ast.Position {}
+  1334  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1335  .  .  .  .  .  0: nil
+  1336  .  .  .  .  }
+  1337  .  .  .  }
+  1338  .  .  }
+  1339  .  }
+  1340  }

--- a/internal/testdata/expected/javascript/ir/expressions.js.out
+++ b/internal/testdata/expected/javascript/ir/expressions.js.out
@@ -1,20 +1,36 @@
 file expressions.js:
-  import  express
-  func  %fn2    ()
-  var   app    
+  import  express      
+  func  %fn3          ()
+  var   app          
+  func  incrementExpr ()
 
 
 
 ============================
 
-# Name: %fn2
+# Name: %fn3
 # File: expressions.js
 # Location: expressions.js:1:0
-func %fn2():
+func %fn3():
 0:                                                                         entry
 	%t0 = console.log("testing")
-	%t1 = make closure %fn2$1 
+	%t1 = make closure %fn3$1 
 	%t2 = app.get("/", %t1)
-	%t3 = make closure %fn2$2 
+	%t3 = make closure %fn3$2 
 	%t4 = app.set("/", %t3)
+
+# Name: incrementExpr
+# File: expressions.js
+# Location: expressions.js:32:0
+# Locals:
+#   0:	a
+#   1:	a
+#   2:	a
+func incrementExpr():
+0:                                                                         entry
+	%t0 = "0"
+	%t1 = %t0 + "1"
+	%t2 = %t1 - "1"
+	return %t2
+1:                                                                   unreachable
 

--- a/internal/testdata/expected/javascript/ir/statements.js.out
+++ b/internal/testdata/expected/javascript/ir/statements.js.out
@@ -1,11 +1,15 @@
 file statements.js:
-  func  ExportStatement ()
-  func  ForInStatement  ()
-  func  ForStatement    ()
-  func  IfStatement     (a, b)
-  func  SwitchStatement ()
-  func  TryStatement    ()
-  func  WhileStatement  ()
+  func  ExportStatement                             ()
+  func  ForInStatement                              ()
+  func  ForStatement                                ()
+  func  ForStatementEmptyBody                       ()
+  func  ForStatementEndlessRecursion                ()
+  func  ForStatementIteratingOverList               (data)
+  func  ForStatementWithoutBinaryExpressionIncremet ()
+  func  IfStatement                                 (a, b)
+  func  SwitchStatement                             ()
+  func  TryStatement                                ()
+  func  WhileStatement                              ()
 
 
 
@@ -13,13 +17,13 @@ file statements.js:
 
 # Name: ExportStatement
 # File: statements.js
-# Location: statements.js:99:0
+# Location: statements.js:127:0
 func ExportStatement():
 0:                                                                         entry
 
 # Name: ForInStatement
 # File: statements.js
-# Location: statements.js:91:0
+# Location: statements.js:119:0
 # Locals:
 #   0:	values
 func ForInStatement():
@@ -29,8 +33,90 @@ func ForInStatement():
 # Name: ForStatement
 # File: statements.js
 # Location: statements.js:85:0
+# Locals:
+#   0:	i
+#   1:	i
+#   2:	i
 func ForStatement():
 0:                                                                         entry
+	jump 2
+1:                                                                      for.body
+	%t3 = %t1 + "1"
+	%t4 = console.log(%t3)
+	jump 2
+2:                                                                      for.loop
+	%t0 = "0"
+	%t1 = phi [2: %t0, 1: %t3] #i
+	%t2 = %t1 < "9"
+	if %t2 goto 1 else 3
+3:                                                                      for.done
+
+# Name: ForStatementEmptyBody
+# File: statements.js
+# Location: statements.js:112:0
+# Locals:
+#   0:	i
+#   1:	i
+#   2:	i
+func ForStatementEmptyBody():
+0:                                                                         entry
+	jump 2
+1:                                                                      for.body
+	%t3 = %t1 + "1"
+	jump 2
+2:                                                                      for.loop
+	%t0 = "0"
+	%t1 = phi [2: %t0, 1: %t3] #i
+	%t2 = %t1 < l
+	if %t2 goto 1 else 3
+3:                                                                      for.done
+
+# Name: ForStatementEndlessRecursion
+# File: statements.js
+# Location: statements.js:106:0
+func ForStatementEndlessRecursion():
+0:                                                                         entry
+	jump 1
+1:                                                                      for.body
+	%t0 = console.log("endless recursion")
+	jump 1
+2:                                                                      for.done
+
+# Name: ForStatementIteratingOverList
+# File: statements.js
+# Location: statements.js:92:0
+# Locals:
+#   0:	i
+#   1:	i
+#   2:	i
+#   3:	sum
+func ForStatementIteratingOverList(data):
+0:                                                                         entry
+	%t0 = "0"
+	jump 2
+1:                                                                      for.body
+	%t4 = %t2 + "1"
+	jump 2
+2:                                                                      for.loop
+	%t1 = "0"
+	%t2 = phi [2: %t1, 1: %t4] #i
+	%t3 = %t2 < data.length
+	if %t3 goto 1 else 3
+3:                                                                      for.done
+	return %t0
+4:                                                                   unreachable
+
+# Name: ForStatementWithoutBinaryExpressionIncremet
+# File: statements.js
+# Location: statements.js:101:0
+func ForStatementWithoutBinaryExpressionIncremet():
+0:                                                                         entry
+	jump 2
+1:                                                                      for.body
+	jump 2
+2:                                                                      for.loop
+	if c goto 1 else 3
+3:                                                                      for.done
 
 # Name: IfStatement
 # File: statements.js

--- a/internal/testdata/source/javascript/expressions.js
+++ b/internal/testdata/source/javascript/expressions.js
@@ -27,3 +27,11 @@ app.get('/', (req, res) => {
 app.set('/', (req, res) => {
     console.log(req, res)
 });
+
+
+function incrementExpr() {
+    let a = 0;
+    a++
+    a--
+    return a
+}

--- a/internal/testdata/source/javascript/statements.js
+++ b/internal/testdata/source/javascript/statements.js
@@ -86,6 +86,34 @@ function ForStatement() {
     for (let i = 0; i < 9; i++) {
         console.log(i);
     }
+
+}
+
+function ForStatementIteratingOverList(data) {
+    let sum = 0;
+    for (let i =0; i < data.length; i++) {
+        sum += i;
+    }
+
+    return sum
+}
+
+function ForStatementWithoutBinaryExpressionIncremet() {
+    for (var a, b; c; d)
+        e;
+}
+
+function ForStatementEndlessRecursion() {
+    for (;;) {
+        console.log("endless recursion");
+    }
+}
+
+function ForStatementEmptyBody() {
+    for (var i = 0
+        ; i < l
+        ; i++) {
+    }
 }
 
 function ForInStatement() {


### PR DESCRIPTION
This commit add support for for loop's on IR.

Initially to add this support some bugs was fixed on parse from
tree-sitter CST to generic AST; Previously we was parsing the for
statement condition as a statement, which always result in a
ast.ExprStmt, so the Cond was changed to store the expression directly
which facilitated the parse in the IR. The increment node on for loop
could be nil in some syntaxes, or a empty_statement, so this commit also
handle these cases. A new field Op was also added on ast.IncExpr to
store the operator of a increment expression (++ or --).

On IR this commit add support for for loop's and increment expression
(since increment expressions is almost always used on for loop's). The
increment expression is converted to a binary expression, so a++ is
converted to a = a + 1. No new struct was needed to support for loops,
the implementation basically uses basic blocks and jumps to represent
the loops. With this loop representation a bug was also founded on
Function.lookup, since we can have recursively predecessors blocks that
points to each other the Function.recursivelyLookup it was going into an
infinite loop. To fix this issue, a map with the visited basic blocks
was created, so Function.recursivelyLookup check if the block being
visited was already visited, if yes stop the recursion, if no, search for
the local variable and add the basic block on the map of visited blocks.

This commit looks big, but the changes are almost all changes to the
test file.
