### PR TITLE
analysis:chore - add new testcases

### DIFF
--- a/semantic/analysis/value/value_test.go
+++ b/semantic/analysis/value/value_test.go
@@ -70,20 +70,36 @@ function f() {
 		},
 		{
 			Name: "MatchContains",
-			Src:  `function f() { crypto.createHash('md5') }`,
+			Src: `
+function f1() { crypto.createHash('sha256') }
+function f2() { crypto.createHash('md5') }
+`,
 			Analyzer: &call.Analyzer{
 				Name:      "crypto.createHash",
 				ArgsIndex: 1,
 				ArgValue: value.Contains{
-					Values: []string{"md5"},
+					Values: []string{"sha256"},
 				},
 			},
-			ExpectedIssues: []analysis.Issue{},
+			ExpectedIssues: []analysis.Issue{
+				{
+					Filename:    "MatchContains",
+					StartOffset: 63,
+					EndOffset:   87,
+					Line:        3,
+					Column:      16,
+				},
+			},
 		},
 		{
 			Name: "MatchContainsUsingVariable",
 			Src: `
-function f() {
+function f1() {
+	const algorithmn = 'sha256'
+	crypto.createHash(algorithmn) 
+}
+
+function f2() {
 	const algorithmn = 'md5'
 	crypto.createHash(algorithmn) 
 }
@@ -92,10 +108,71 @@ function f() {
 				Name:      "crypto.createHash",
 				ArgsIndex: 1,
 				ArgValue: value.Contains{
-					Values: []string{"md5"},
+					Values: []string{"sha256"},
 				},
 			},
-			ExpectedIssues: []analysis.Issue{},
+			ExpectedIssues: []analysis.Issue{
+				{
+					Filename:    "MatchContainsUsingVariable",
+					StartOffset: 124,
+					EndOffset:   153,
+					Line:        9, Column: 1,
+				},
+			},
+		},
+		{
+			Name: "MatchContainsUsingGlobalVariable",
+			Src: `
+const algorithmn = 'md5'
+function f() {
+	crypto.createHash(algorithmn) 
+}
+`,
+			Analyzer: &call.Analyzer{
+				Name:      "crypto.createHash",
+				ArgsIndex: 1,
+				ArgValue: value.Contains{
+					Values: []string{"sha256"},
+				},
+			},
+			ExpectedIssues: []analysis.Issue{
+				{
+					Filename:    "MatchContainsUsingGlobalVariable",
+					StartOffset: 42,
+					EndOffset:   71,
+					Line:        4, Column: 1,
+				},
+			},
+		},
+		{
+			Name: "MatchPhiValuesIsConst",
+			Src: `
+function f(arg) {
+	if (arg) {
+		const x = arg
+		const y = 'const true'
+	} else {
+		const x = 'const'
+		const y = 'const false'
+	}
+	insecureCall(x)
+	insecureCall(y)
+}
+`,
+			Analyzer: &call.Analyzer{
+				Name:      "insecureCall",
+				ArgsIndex: 1,
+				ArgValue:  value.IsConst,
+			},
+			ExpectedIssues: []analysis.Issue{
+				{
+					Filename:    "MatchPhiValuesIsConst",
+					StartOffset: 132,
+					EndOffset:   147,
+					Line:        10,
+					Column:      1,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This commit introduce some new test cases for analysis/call and
analysis/value packages. This commit also change the testutil package to
handle struct declarations when executing the tests.