### PR TITLE
javascript/ast:fix - panic when parsing return without stmt

### DIFF
--- a/internal/horusec-javascript/ast.go
+++ b/internal/horusec-javascript/ast.go
@@ -315,18 +315,26 @@ func (p *parser) parseStmt(node *cst.Node) ast.Stmt {
 			}
 		}
 	case ReturnStatement:
-		expr := node.NamedChild(0)
-		if expr.Type() == SequenceExpression {
+		if expr := node.NamedChild(0); expr != nil {
+			if expr.Type() == SequenceExpression {
+				return &ast.ReturnStmt{
+					Results:  p.parseSequenceExpr(expr),
+					Position: ast.NewPosition(node),
+				}
+			}
+
 			return &ast.ReturnStmt{
-				Results:  p.parseSequenceExpr(expr),
-				Position: ast.NewPosition(node),
+				Position: ast.NewPosition(expr),
+				Results: []ast.Expr{
+					p.parseExpr(expr),
+				},
 			}
 		}
 
+		// Return without any statement
 		return &ast.ReturnStmt{
-			Results: []ast.Expr{
-				p.parseExpr(expr),
-			},
+			Position: ast.NewPosition(node),
+			Results:  make([]ast.Expr, 0),
 		}
 	case IfStatement:
 		stmt := &ast.IfStmt{


### PR DESCRIPTION
Previously if we try to parse a return without any statement we had a
nil pointer panic. This commit add a simple validation to check if the
return has statement, if it has, parse it, otherwise return a
ast.ReturnStmt without any results.

Signed-off-by: Matheus Alcantara <matheus.alcantara@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
