### PR TITLE
javascript/ast:fix - new expression outside var decl

### DIFF
--- a/internal/horusec-javascript/ast.go
+++ b/internal/horusec-javascript/ast.go
@@ -541,19 +541,20 @@ func (p *parser) parseExpr(node *cst.Node) ast.Expr {
 			Position: ast.NewPosition(node),
 		}
 	case NewExpression:
-		parent := node.Parent()
-		p.assertNodeType(parent, VariableDeclarator)
+		var name *ast.Ident
+		if parent := node.Parent(); parent.Type() == VariableDeclarator {
+			if n := parent.ChildByFieldName("name"); n != nil && n.Type() == Identifier {
+				name = ast.NewIdent(n)
+			}
+		}
 
 		var args []ast.Expr
 		p.iterNamedChilds(node.ChildByFieldName("arguments"), func(node *cst.Node) {
 			args = append(args, p.parseExpr(node))
 		})
 
-		name := parent.ChildByFieldName("name")
-		p.assertNodeType(name, Identifier)
-
 		return &ast.ObjectExpr{
-			Name:     ast.NewIdent(name),
+			Name:     name,
 			Type:     p.parseExpr(node.ChildByFieldName("constructor")),
 			Elts:     args,
 			Position: ast.NewPosition(node),

--- a/internal/testdata/expected/javascript/ast/var_declarations.js.out
+++ b/internal/testdata/expected/javascript/ast/var_declarations.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "var_declarations.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 10) {
+     6  .  Decls: []ast.Decl (len = 11) {
      7  .  .  0: *ast.ValueDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Names: []*ast.Ident (len = 1) {
@@ -317,5 +317,50 @@
    316  .  .  .  .  }
    317  .  .  .  }
    318  .  .  }
-   319  .  }
-   320  }
+   319  .  .  10: *ast.FuncDecl {
+   320  .  .  .  Position: ast.Position {}
+   321  .  .  .  Name: *ast.Ident {
+   322  .  .  .  .  Name: "f1"
+   323  .  .  .  .  Position: ast.Position {}
+   324  .  .  .  }
+   325  .  .  .  Type: *ast.FuncType {
+   326  .  .  .  .  Position: ast.Position {}
+   327  .  .  .  .  Params: *ast.FieldList {
+   328  .  .  .  .  .  Position: ast.Position {}
+   329  .  .  .  .  }
+   330  .  .  .  }
+   331  .  .  .  Body: *ast.BlockStmt {
+   332  .  .  .  .  Position: ast.Position {}
+   333  .  .  .  .  List: []ast.Stmt (len = 1) {
+   334  .  .  .  .  .  0: *ast.ExprStmt {
+   335  .  .  .  .  .  .  Position: ast.Position {}
+   336  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   337  .  .  .  .  .  .  .  Position: ast.Position {}
+   338  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   339  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   340  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   341  .  .  .  .  .  .  .  .  .  Name: "console"
+   342  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   343  .  .  .  .  .  .  .  .  }
+   344  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   345  .  .  .  .  .  .  .  .  .  Name: "log"
+   346  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   347  .  .  .  .  .  .  .  .  }
+   348  .  .  .  .  .  .  .  }
+   349  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   350  .  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
+   351  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   352  .  .  .  .  .  .  .  .  .  Type: *ast.Ident {
+   353  .  .  .  .  .  .  .  .  .  .  Name: "Object"
+   354  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   355  .  .  .  .  .  .  .  .  .  }
+   356  .  .  .  .  .  .  .  .  .  Comment: "constructor"
+   357  .  .  .  .  .  .  .  .  }
+   358  .  .  .  .  .  .  .  }
+   359  .  .  .  .  .  .  }
+   360  .  .  .  .  .  }
+   361  .  .  .  .  }
+   362  .  .  .  }
+   363  .  .  }
+   364  .  }
+   365  }

--- a/internal/testdata/expected/javascript/ir/var_declarations.js.out
+++ b/internal/testdata/expected/javascript/ir/var_declarations.js.out
@@ -5,6 +5,7 @@ file var_declarations.js:
   var   d  
   var   e  
   var   f  
+  func  f1  ()
   var   foo
   func  g   (a, b)
   var   h  
@@ -13,6 +14,14 @@ file var_declarations.js:
 
 
 ============================
+
+# Name: f1
+# File: var_declarations.js
+# Location: var_declarations.js:37:0
+func f1():
+0:                                                                         entry
+	%t0 = constructor(Object)
+	%t1 = console.log(%t0)
 
 # Name: g
 # File: var_declarations.js

--- a/internal/testdata/source/javascript/var_declarations.js
+++ b/internal/testdata/source/javascript/var_declarations.js
@@ -33,3 +33,7 @@ const h = 1, b = 2;
 let i;
 
 let foo = bar();
+
+function f1() {
+    console.log(new Object())
+}


### PR DESCRIPTION
Previously the new_expression handle parser was always expecting that
the parent node was a variable declaration, witch it's not true because
we can have a code like this: foo(new Bar()).

This commit fix this issue by setting the ast.ObjectExpr.Name field only
if the parent node of new_expression is a variable_declarator.

