### PR TITLE
ir:fix - invalid selector expr when using declared variable

### DIFF
--- a/internal/ir/builder.go
+++ b/internal/ir/builder.go
@@ -484,12 +484,18 @@ func (b *builder) selectorExpr(fn *Function, expr ast.Expr) Value {
 
 	switch e := expr.(type) {
 	case *ast.Ident:
-		// e.Name could be an alias imported name, so we need to check if this
-		// identifier is imported so we use your real name. Otherwise we just
-		// use the expression identifier name.
 		if importt := fn.File.ImportedPackage(e.Name); importt != nil {
+			// e.Name could be an alias imported name, so we need to check if this
+			// identifier is imported so we use your real name. Otherwise we just
+			// use the expression identifier name.
 			name = importt.Path
+		} else if v := b.lookup(fn, e.Name); v != nil {
+			// e.Name could also be an identifier to a previously declared variable
+			// so we lookup to get the correctly name.
+			name = v.Name()
 		} else {
+			// Otherwise we just use the identifier name, since we can't find any
+			// reference to this identifier.
 			name = e.Name
 		}
 	case *ast.SelectorExpr:

--- a/internal/testdata/expected/javascript/ast/functions.js.out
+++ b/internal/testdata/expected/javascript/ast/functions.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "functions.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 15) {
+     6  .  Decls: []ast.Decl (len = 16) {
      7  .  .  0: *ast.ImportDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -1458,5 +1458,64 @@
   1457  .  .  .  .  }
   1458  .  .  .  }
   1459  .  .  }
-  1460  .  }
-  1461  }
+  1460  .  .  15: *ast.FuncDecl {
+  1461  .  .  .  Position: ast.Position {}
+  1462  .  .  .  Name: *ast.Ident {
+  1463  .  .  .  .  Name: "f13"
+  1464  .  .  .  .  Position: ast.Position {}
+  1465  .  .  .  }
+  1466  .  .  .  Type: *ast.FuncType {
+  1467  .  .  .  .  Position: ast.Position {}
+  1468  .  .  .  .  Params: *ast.FieldList {
+  1469  .  .  .  .  .  Position: ast.Position {}
+  1470  .  .  .  .  }
+  1471  .  .  .  }
+  1472  .  .  .  Body: *ast.BlockStmt {
+  1473  .  .  .  .  Position: ast.Position {}
+  1474  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1475  .  .  .  .  .  0: *ast.AssignStmt {
+  1476  .  .  .  .  .  .  Position: ast.Position {}
+  1477  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1478  .  .  .  .  .  .  .  0: *ast.Ident {
+  1479  .  .  .  .  .  .  .  .  Name: "a"
+  1480  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1481  .  .  .  .  .  .  .  }
+  1482  .  .  .  .  .  .  }
+  1483  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1484  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
+  1485  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1486  .  .  .  .  .  .  .  .  Name: *ast.Ident {
+  1487  .  .  .  .  .  .  .  .  .  Name: "a"
+  1488  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1489  .  .  .  .  .  .  .  .  }
+  1490  .  .  .  .  .  .  .  .  Type: *ast.Ident {
+  1491  .  .  .  .  .  .  .  .  .  Name: "A"
+  1492  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1493  .  .  .  .  .  .  .  .  }
+  1494  .  .  .  .  .  .  .  .  Comment: "constructor"
+  1495  .  .  .  .  .  .  .  }
+  1496  .  .  .  .  .  .  }
+  1497  .  .  .  .  .  }
+  1498  .  .  .  .  .  1: *ast.ExprStmt {
+  1499  .  .  .  .  .  .  Position: ast.Position {}
+  1500  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1501  .  .  .  .  .  .  .  Position: ast.Position {}
+  1502  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1503  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1504  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1505  .  .  .  .  .  .  .  .  .  Name: "a"
+  1506  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1507  .  .  .  .  .  .  .  .  }
+  1508  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1509  .  .  .  .  .  .  .  .  .  Name: "foo"
+  1510  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1511  .  .  .  .  .  .  .  .  }
+  1512  .  .  .  .  .  .  .  }
+  1513  .  .  .  .  .  .  .  Args: []ast.Expr (len = 0) {}
+  1514  .  .  .  .  .  .  }
+  1515  .  .  .  .  .  }
+  1516  .  .  .  .  }
+  1517  .  .  .  }
+  1518  .  .  }
+  1519  .  }
+  1520  }

--- a/internal/testdata/expected/javascript/ir/expressions.js.out
+++ b/internal/testdata/expected/javascript/ir/expressions.js.out
@@ -15,9 +15,11 @@ func %fn3():
 0:                                                                         entry
 	%t0 = console.log("testing")
 	%t1 = make closure %fn3$1 
-	%t2 = app.get("/", %t1)
-	%t3 = make closure %fn3$2 
-	%t4 = app.set("/", %t3)
+	%t2 = express.express()
+	%t3 = %t2.get("/", %t1)
+	%t4 = make closure %fn3$2 
+	%t5 = express.express()
+	%t6 = %t5.set("/", %t4)
 
 # Name: incrementExpr
 # File: expressions.js

--- a/internal/testdata/expected/javascript/ir/functions.js.out
+++ b/internal/testdata/expected/javascript/ir/functions.js.out
@@ -5,6 +5,7 @@ file functions.js:
   func  f10 ()
   func  f11 ()
   func  f12 ()
+  func  f13 ()
   func  f2  (a)
   func  f3  (a, b)
   func  f4  ()
@@ -70,6 +71,16 @@ func f12():
 0:                                                                         entry
 	%t0 = array["1","2","3"]
 	%t1 = console.log(%t0)
+
+# Name: f13
+# File: functions.js
+# Location: functions.js:101:0
+# Locals:
+#   0:	a
+func f13():
+0:                                                                         entry
+	%t0 = constructor(A)
+	%t1 = %t0.foo()
 
 # Name: f2
 # File: functions.js
@@ -167,8 +178,8 @@ func f8(a):
 # File: functions.js
 # Location: functions.js:69:0
 # Locals:
-#   0:	a
-#   1:	a.b
+#   0:	%t4.b
+#   1:	a
 #   2:	b
 func f9(a):
 0:                                                                         entry

--- a/internal/testdata/source/javascript/functions.js
+++ b/internal/testdata/source/javascript/functions.js
@@ -97,3 +97,8 @@ const i = [1,2,3]
 function f12() {
 	console.log(i)
 }
+
+function f13() {
+    let a = new A();
+    a.foo()
+}


### PR DESCRIPTION
Previously if we define a new variable and call a method or use a field
from this create variable the method builder.selectorExpr was not
lookuping the correct name for this variable, example:
Source:
```
    let a = new A()
    a.doSomething()
```
IR:
```
    %t0 = constructor(A)
    %t1 = a.doSomething()
```

This commit fix this issue by adding a new else if on builder.selectorExpr
to try to lookup the identifier name, and if the variable exists, use
their name instead the name of identifier, with this, the following
correctly IR is generated:
```
    %t0 = constructor(A)
    %t1 = %t0.doSomething()
```

