### PR TITLE
ir:feat - better approach to parse *ast.SelectorExpr

### DIFF
--- a/internal/ir/create.go
+++ b/internal/ir/create.go
@@ -52,8 +52,8 @@ func NewFile(f *ast.File) *File {
 				Path:  decl.Path.Name,
 				Alias: identNameIfNotNil(decl.Alias),
 			}
-			file.Members[importt.Name()] = importt
-			file.imported[importt.Name()] = importt
+			file.Members[importt.ImportName()] = importt
+			file.imported[importt.ImportName()] = importt
 		case *ast.ValueDecl:
 			for _, g := range valueDecl(decl) {
 				file.Members[g.Name()] = g

--- a/internal/testdata/expected/javascript/ir/functions.js.out
+++ b/internal/testdata/expected/javascript/ir/functions.js.out
@@ -80,7 +80,7 @@ func f12():
 func f13():
 0:                                                                         entry
 	%t0 = constructor(A)
-	%t1 = %t0.foo()
+	%t1 = A.foo()
 
 # Name: f2
 # File: functions.js
@@ -188,6 +188,6 @@ func f9(a):
 	%t2 = a.b.c()
 	%t3 = a.b("10")
 	%t4 = %t3.c.d("20")
-	%t5 = nil
+	%t5 = %t4.b.c.d.e
 	%t6 = c()
 

--- a/semantic/analysis/call/call_test.go
+++ b/semantic/analysis/call/call_test.go
@@ -242,6 +242,32 @@ function f() {
 				},
 			},
 		},
+		{
+			Name: "MatchMethodCallFromObject",
+			Src: `
+class T {
+	insecure() {}
+}
+
+function f() {
+	let x = new T();
+	x.insecure();
+}
+			`,
+			Analyzer: &call.Analyzer{
+				Name:      "T.insecure",
+				ArgsIndex: call.NoArguments,
+			},
+			ExpectedIssues: []analysis.Issue{
+				{
+					Filename:    "MatchMethodCallFromObject",
+					StartOffset: 63,
+					EndOffset:   75,
+					Line:        8,
+					Column:      1,
+				},
+			},
+		},
 	}
 	testutil.TestAnalayzer(t, testcases)
 }


### PR DESCRIPTION
Previously our parsing strategy of *ast.SelectorExpr was very simple, we
basically created a variable whose name was the concatenation of
ast.SelectorExpr.Expr and ast.SelectorExpr.Sel. Although this approach
works well, it's very simple and doesn't allow us to write rules that
look for method calls on specific objects.
Suppose we need to write a rule for a method call on an object Foo:
```
    let foo = new Foo()
    foo.something()
```
The code above was generating the following IR:
```
    %t0 = constructor(Foo)
    %t1 = %t0.something()
```
As mentioned above, the selector expression that holds foo variable and
something function call was resulting in a function call witch
%t0.something as your name (since the %t0 is the variable that holds the
Foo instance). This approach is pretty bad because we can't write a rule
for a function call of object Foo, we would write a generic rule that
match any function call to something(even if the function call is from
another object).

This commit improve the approach used to parse *ast.SelectorExpr.
Basically a new ir.Selector Value was created that holds the variable
being accessed (from ast.Selector.Sel) and the expression used to access
this variable (from ast.Selector.Expr). With this we can have a better
context of what values are being accessed on ast.SelectorExpr and
consequently be able to write more assertive rules. With this approach
the following IR is generated from the code above:
```
    %t0 = constructor(Foo)
    %t1 = Foo.something()
```

With this IR we can write rules that check methods calls from objects
with the complete path of this object and not just the name of method
being called (we can write a rule that match Foo.something and not just
.*\.something for example).

