### PR TITLE
ir:feat: add support for labeled statements

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -337,7 +337,7 @@ type (
 	LabeledStatement struct {
 		Position
 		Label *Ident // LabeledStatement label
-		Body  []Stmt
+		Body  Stmt
 	}
 )
 

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -197,7 +197,7 @@ func Walk(v Visitor, node Node) {
 		if n.Label != nil {
 			Walk(v, n.Label)
 		}
-		walkStmtList(v, n.Body)
+		Walk(v, n.Body)
 
 	// Declarations
 	case *ImportDecl:

--- a/internal/horusec-javascript/ast.go
+++ b/internal/horusec-javascript/ast.go
@@ -479,17 +479,16 @@ func (p *parser) parseStmt(node *cst.Node) ast.Stmt {
 		stmt := &ast.LabeledStatement{
 			Position: ast.NewPosition(node),
 		}
-		body := make([]ast.Stmt, 0, node.NamedChildCount())
 
-		// The first named child of switch case is the condition, here we just need to iterate over the
-		// statements of switch case. The condition of switch case is parsed above.
-		for i := 1; i < node.NamedChildCount(); i++ {
-			body = append(body, p.parseStmt(node.NamedChild(i)))
+		// labeled_statemtn can have two named child nodes; label and body. Here we check if we have
+		// the body of labeled statement, if we, parse it as the body of labeled statement.
+		if node.NamedChildCount() > 1 {
+			stmt.Body = p.parseStmt(node.NamedChild(1))
 		}
+
 		if label := node.ChildByFieldName("label"); label != nil {
 			stmt.Label = ast.NewIdent(label)
 		}
-		stmt.Body = body
 
 		return stmt
 	case ExportStatement, EmptyStatement:

--- a/internal/ir/builder.go
+++ b/internal/ir/builder.go
@@ -194,10 +194,56 @@ func (fn *Function) finishBody() {
 	fn.currentBlock = nil
 }
 
+// labelledBlock returns the branch target associated with the specified label, creating it if needed.
+func (fn *Function) labelledBlock(name string) *lblock {
+	label, exists := fn.lblocks[name]
+	if !exists {
+		label = &lblock{_goto: fn.newBasicBlock(name)}
+		fn.lblocks[name] = label
+	}
+	return label
+}
+
 // emit appends an instruction to the current basic block.
 // If the instruction defines a Value, it is returned.
 func (b *BasicBlock) emit(i Instruction) {
 	b.Instrs = append(b.Instrs, i)
+}
+
+// targets holds the destination associated for unlabelled for/while/switch stmts.
+// We push/pop one of these as we enter/leave each statement construct.
+type targets []*lblock
+
+// push add a new block on stack.
+func (t *targets) push(label *lblock) {
+	*t = append(*t, label)
+}
+
+// pop remove the last block from stack.
+func (t *targets) pop() {
+	if len(*t) == 0 {
+		panic("empty targets stack to pop")
+	}
+	old := *t
+	n := len(old)
+	old[n-1] = nil // avoid memory leak
+	*t = old[:n-1]
+}
+
+// head return the last item from stack without removing.
+func (t targets) head() *lblock {
+	n := len(t)
+	if n == 0 {
+		return nil
+	}
+	return t[n-1]
+}
+
+// lblock contains destinations associated with for/while/switch stmts.
+type lblock struct {
+	_goto     *BasicBlock
+	_break    *BasicBlock
+	_continue *BasicBlock
 }
 
 // builder controls how a function is converted from AST to a IR.
@@ -216,6 +262,9 @@ func (b *builder) buildFunction(fn *Function, body *ast.BlockStmt) {
 //
 // nolint:gocyclo // Its better centralize all stmt to IR conversion on a single function.
 func (b *builder) stmt(fn *Function, s ast.Stmt) {
+	var label *lblock
+
+start:
 	switch stmt := s.(type) {
 	case *ast.BlockStmt:
 		b.stmtList(fn, stmt.List)
@@ -264,13 +313,46 @@ func (b *builder) stmt(fn *Function, s ast.Stmt) {
 
 		fn.currentBlock = done
 	case *ast.ForStatement:
-		b.forStmt(fn, stmt)
+		b.forStmt(fn, stmt, label)
 	case *ast.TryStmt:
 		b.tryStatement(fn, stmt)
 	case *ast.WhileStmt:
-		b.whileStmt(fn, stmt)
+		b.whileStmt(fn, stmt, label)
 	case *ast.SwitchStatement:
 		b.switchStatement(fn, stmt)
+	case *ast.LabeledStatement:
+		label = fn.labelledBlock(stmt.Label.Name)
+		emitJump(fn, label._goto)
+		fn.currentBlock = label._goto
+		s = stmt.Body
+		goto start // effectively: tailcall stmt(fn, s.Stmt, label)
+
+	case *ast.BreakStatement, *ast.ContinueStatement:
+		var block *BasicBlock
+
+		switch s := stmt.(type) {
+		case *ast.BreakStatement:
+			if s.Label != nil {
+				block = fn.labelledBlock(s.Label.Name)._break
+			} else {
+				if h := fn.targets.head(); h != nil {
+					block = h._break
+				}
+			}
+		case *ast.ContinueStatement:
+			if s.Label != nil {
+				block = fn.labelledBlock(s.Label.Name)._continue
+			} else {
+				if h := fn.targets.head(); h != nil {
+					block = h._continue
+				}
+			}
+		}
+
+		if block != nil {
+			emitJump(fn, block)
+			fn.currentBlock = fn.newBasicBlock("unreachable")
+		}
 	case *ast.BadNode:
 		// Do nothing with bad nodes.
 	default:
@@ -655,7 +737,7 @@ func (b *builder) expr(fn *Function, e ast.Expr, expand bool) Value {
 // so in this case we consider the variable value for the predecessor block that was already
 // processed at the this point. In this case, the while.cond block is an incomplete block because
 // the while.body block is added as predecessor after issuing the code of while.cond block.
-func (b *builder) whileStmt(fn *Function, stmt *ast.WhileStmt) {
+func (b *builder) whileStmt(fn *Function, stmt *ast.WhileStmt, label *lblock) {
 	// Create the while body.
 	body := fn.newBasicBlock("while.body")
 
@@ -676,6 +758,12 @@ func (b *builder) whileStmt(fn *Function, stmt *ast.WhileStmt) {
 	// Create the while done block that holds code after the while statement.
 	done := fn.newBasicBlock("while.done")
 
+	if label != nil {
+		// whileStmt is processing a labeled statement, so we set the break and continue jumps.
+		label._break = done
+		label._continue = cond
+	}
+
 	if stmt.Cond != nil {
 		// Emit the while condition if exists and set the current block
 		// from while.cond to while.body.
@@ -683,11 +771,20 @@ func (b *builder) whileStmt(fn *Function, stmt *ast.WhileStmt) {
 		fn.currentBlock = body
 	}
 
+	// Push the new target block to process the loop body.
+	fn.targets.push(&lblock{
+		_break:    done,
+		_continue: cond,
+	})
+
 	// Emit the while body and emit a jump from while.body to while.cond to represent
 	// the loop. Note that if while statement don't have a condition this emission will
 	// be for the while.body again to represent the endless recursion.
 	b.stmt(fn, stmt.Body)
 	emitJump(fn, cond)
+
+	// Since the body was already parsed, pop the target block from stack.
+	fn.targets.pop()
 
 	// Set current block to while.done to further processing code after while statement.
 	fn.currentBlock = done
@@ -707,7 +804,7 @@ func (b *builder) whileStmt(fn *Function, stmt *ast.WhileStmt) {
 //         ...code after loop...
 //
 // nolint: funlen,gocyclo // For loops are complicated, we can improve this in the future.
-func (b *builder) forStmt(fn *Function, stmt *ast.ForStatement) {
+func (b *builder) forStmt(fn *Function, stmt *ast.ForStatement, label *lblock) {
 	// Create the body of for loop.
 	body := fn.newBasicBlock("for.body")
 
@@ -756,6 +853,12 @@ func (b *builder) forStmt(fn *Function, stmt *ast.ForStatement) {
 	// Create for.done block to jump if for statement has a condition.
 	done := fn.newBasicBlock("for.done")
 
+	if label != nil {
+		// forStmt is processing a labeled statement, so we set the break and continue jumps.
+		label._break = done
+		label._continue = loop
+	}
+
 	// Emit for loop condition to fn if exists.
 	if stmt.Cond != nil {
 		b.cond(fn, stmt.Cond, body, done)
@@ -776,8 +879,17 @@ func (b *builder) forStmt(fn *Function, stmt *ast.ForStatement) {
 		}
 	}
 
+	// Push the new target block to process the loop body.
+	fn.targets.push(&lblock{
+		_break:    done,
+		_continue: loop,
+	})
+
 	// Emit the for body on loop.body block.
 	b.stmt(fn, stmt.Body)
+
+	// Since the body was already parsed, pop the target block from stack.
+	fn.targets.pop()
 
 	// Emit a jump from for.body to to for.loop again.
 	emitJump(fn, loop)

--- a/internal/ir/create.go
+++ b/internal/ir/create.go
@@ -103,6 +103,7 @@ func (f *File) NewFunction(name string, syntax ast.Node) *Function {
 		phis:      make(map[string]*Phi),
 		nLocals:   0,
 		parent:    nil,
+		lblocks:   make(map[string]*lblock),
 	}
 
 	return fn

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -114,7 +114,9 @@ type Function struct {
 
 	// The following fields are set transiently during building,
 	// then cleared.
-	currentBlock *BasicBlock // Where to add instructions.
+	currentBlock *BasicBlock        // Where to add instructions.
+	lblocks      map[string]*lblock // Labeled blocks.
+	targets      targets            // Stack of branch targets.
 }
 
 // Signature represents a function or method signature.

--- a/internal/testdata/expected/javascript/ast/statements.js.out
+++ b/internal/testdata/expected/javascript/ast/statements.js.out
@@ -4,7 +4,7 @@
      3  .  .  Name: "statements.js"
      4  .  .  Position: ast.Position {}
      5  .  }
-     6  .  Decls: []ast.Decl (len = 20) {
+     6  .  Decls: []ast.Decl (len = 22) {
      7  .  .  0: *ast.FuncDecl {
      8  .  .  .  Position: ast.Position {}
      9  .  .  .  Name: *ast.Ident {
@@ -933,1803 +933,2206 @@
    932  .  .  .  .  .  .  .  Name: "whileStmt"
    933  .  .  .  .  .  .  .  Position: ast.Position {}
    934  .  .  .  .  .  .  }
-   935  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-   936  .  .  .  .  .  .  .  0: *ast.WhileStmt {
-   937  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   938  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-   939  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   940  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
-   941  .  .  .  .  .  .  .  .  .  .  Name: "x"
-   942  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   943  .  .  .  .  .  .  .  .  .  }
-   944  .  .  .  .  .  .  .  .  .  Op: "<="
-   945  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
-   946  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   947  .  .  .  .  .  .  .  .  .  .  Kind: "number"
-   948  .  .  .  .  .  .  .  .  .  .  Value: "5"
-   949  .  .  .  .  .  .  .  .  .  }
-   950  .  .  .  .  .  .  .  .  }
-   951  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
-   952  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   953  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
-   954  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-   955  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   956  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-   957  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   958  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-   959  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   960  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-   961  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-   962  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   963  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-   964  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-   965  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-   966  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   967  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-   968  .  .  .  .  .  .  .  .  .  .  .  .  }
-   969  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-   970  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-   971  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   972  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-   973  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "test"
-   974  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-   975  .  .  .  .  .  .  .  .  .  .  .  .  }
-   976  .  .  .  .  .  .  .  .  .  .  .  }
-   977  .  .  .  .  .  .  .  .  .  .  }
-   978  .  .  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
-   979  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   980  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-   981  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   982  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
-   983  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
-   984  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   985  .  .  .  .  .  .  .  .  .  .  .  .  }
-   986  .  .  .  .  .  .  .  .  .  .  .  .  Op: "==="
-   987  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
-   988  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   989  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
-   990  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "4"
-   991  .  .  .  .  .  .  .  .  .  .  .  .  }
-   992  .  .  .  .  .  .  .  .  .  .  .  }
-   993  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
-   994  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   995  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
-   996  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-   997  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-   998  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-   999  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1000  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1001  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1002  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1003  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1004  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1005  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1006  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1007  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1008  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1009  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1010  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1011  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1012  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1013  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1014  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1015  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "finish"
-  1016  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1017  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1018  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1019  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1020  .  .  .  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1021  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1022  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Label: *ast.Ident {
-  1023  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "whileStmt"
-  1024  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1025  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1026  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1027  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1028  .  .  .  .  .  .  .  .  .  .  .  }
-  1029  .  .  .  .  .  .  .  .  .  .  }
-  1030  .  .  .  .  .  .  .  .  .  .  2: *ast.IfStmt {
-  1031  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1032  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-  1033  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1034  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
-  1035  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
-  1036  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1037  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1038  .  .  .  .  .  .  .  .  .  .  .  .  Op: "==="
-  1039  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
-  1040  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1041  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
-  1042  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
-  1043  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1044  .  .  .  .  .  .  .  .  .  .  .  }
-  1045  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1046  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1047  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
-  1048  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1049  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1050  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1051  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1052  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1053  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1054  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1055  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1056  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1057  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1058  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1059  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1060  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1061  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1062  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1063  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1064  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1065  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1066  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1067  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "two"
-  1068  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1069  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1070  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1071  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1072  .  .  .  .  .  .  .  .  .  .  .  .  .  1: *ast.ContinueStatement {
-  1073  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1074  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Label: *ast.Ident {
-  1075  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "whileStmt"
-  1076  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1077  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1078  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1079  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1080  .  .  .  .  .  .  .  .  .  .  .  }
-  1081  .  .  .  .  .  .  .  .  .  .  }
-  1082  .  .  .  .  .  .  .  .  .  .  3: *ast.ExprStmt {
-  1083  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1084  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.IncExpr {
-  1085  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1086  .  .  .  .  .  .  .  .  .  .  .  .  Op: "++"
-  1087  .  .  .  .  .  .  .  .  .  .  .  .  Arg: *ast.Ident {
-  1088  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "x"
-  1089  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1090  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1091  .  .  .  .  .  .  .  .  .  .  .  }
-  1092  .  .  .  .  .  .  .  .  .  .  }
-  1093  .  .  .  .  .  .  .  .  .  }
-  1094  .  .  .  .  .  .  .  .  }
-  1095  .  .  .  .  .  .  .  }
-  1096  .  .  .  .  .  .  }
-  1097  .  .  .  .  .  }
-  1098  .  .  .  .  }
-  1099  .  .  .  }
-  1100  .  .  }
-  1101  .  .  6: *ast.FuncDecl {
-  1102  .  .  .  Position: ast.Position {}
-  1103  .  .  .  Name: *ast.Ident {
-  1104  .  .  .  .  Name: "SwitchStatement"
-  1105  .  .  .  .  Position: ast.Position {}
-  1106  .  .  .  }
-  1107  .  .  .  Type: *ast.FuncType {
-  1108  .  .  .  .  Position: ast.Position {}
-  1109  .  .  .  .  Params: *ast.FieldList {
-  1110  .  .  .  .  .  Position: ast.Position {}
-  1111  .  .  .  .  }
-  1112  .  .  .  }
-  1113  .  .  .  Body: *ast.BlockStmt {
-  1114  .  .  .  .  Position: ast.Position {}
-  1115  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1116  .  .  .  .  .  0: *ast.ExprStmt {
-  1117  .  .  .  .  .  .  Position: ast.Position {}
-  1118  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1119  .  .  .  .  .  .  .  Position: ast.Position {}
-  1120  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1121  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1122  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1123  .  .  .  .  .  .  .  .  .  Name: "console"
-  1124  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1125  .  .  .  .  .  .  .  .  }
-  1126  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1127  .  .  .  .  .  .  .  .  .  Name: "log"
-  1128  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   935  .  .  .  .  .  .  Body: *ast.WhileStmt {
+   936  .  .  .  .  .  .  .  Position: ast.Position {}
+   937  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+   938  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   939  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+   940  .  .  .  .  .  .  .  .  .  Name: "x"
+   941  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   942  .  .  .  .  .  .  .  .  }
+   943  .  .  .  .  .  .  .  .  Op: "<="
+   944  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+   945  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   946  .  .  .  .  .  .  .  .  .  Kind: "number"
+   947  .  .  .  .  .  .  .  .  .  Value: "5"
+   948  .  .  .  .  .  .  .  .  }
+   949  .  .  .  .  .  .  .  }
+   950  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+   951  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   952  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
+   953  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+   954  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   955  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   956  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   957  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+   958  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   959  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+   960  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+   961  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   962  .  .  .  .  .  .  .  .  .  .  .  .  }
+   963  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+   964  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+   965  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   966  .  .  .  .  .  .  .  .  .  .  .  .  }
+   967  .  .  .  .  .  .  .  .  .  .  .  }
+   968  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+   969  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+   970  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   971  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+   972  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "test"
+   973  .  .  .  .  .  .  .  .  .  .  .  .  }
+   974  .  .  .  .  .  .  .  .  .  .  .  }
+   975  .  .  .  .  .  .  .  .  .  .  }
+   976  .  .  .  .  .  .  .  .  .  }
+   977  .  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
+   978  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   979  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+   980  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   981  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+   982  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+   983  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   984  .  .  .  .  .  .  .  .  .  .  .  }
+   985  .  .  .  .  .  .  .  .  .  .  .  Op: "==="
+   986  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+   987  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   988  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+   989  .  .  .  .  .  .  .  .  .  .  .  .  Value: "4"
+   990  .  .  .  .  .  .  .  .  .  .  .  }
+   991  .  .  .  .  .  .  .  .  .  .  }
+   992  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+   993  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   994  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+   995  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+   996  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   997  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+   998  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+   999  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1000  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1001  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1002  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1003  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1004  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1005  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1006  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1007  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1008  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1009  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1010  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1011  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1012  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1013  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1014  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "finish"
+  1015  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1016  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1017  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1018  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1019  .  .  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1020  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1021  .  .  .  .  .  .  .  .  .  .  .  .  .  Label: *ast.Ident {
+  1022  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "whileStmt"
+  1023  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1024  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1025  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1026  .  .  .  .  .  .  .  .  .  .  .  }
+  1027  .  .  .  .  .  .  .  .  .  .  }
+  1028  .  .  .  .  .  .  .  .  .  }
+  1029  .  .  .  .  .  .  .  .  .  2: *ast.IfStmt {
+  1030  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1031  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1032  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1033  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1034  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1035  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1036  .  .  .  .  .  .  .  .  .  .  .  }
+  1037  .  .  .  .  .  .  .  .  .  .  .  Op: "==="
+  1038  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1039  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1040  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1041  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
+  1042  .  .  .  .  .  .  .  .  .  .  .  }
+  1043  .  .  .  .  .  .  .  .  .  .  }
+  1044  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1045  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1046  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1047  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1048  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1049  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1050  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1051  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1052  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1053  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1054  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1055  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1056  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1057  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1058  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1059  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1060  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1061  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1062  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1063  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1064  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1065  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1066  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "two"
+  1067  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1068  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1069  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1070  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1071  .  .  .  .  .  .  .  .  .  .  .  .  1: *ast.ContinueStatement {
+  1072  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1073  .  .  .  .  .  .  .  .  .  .  .  .  .  Label: *ast.Ident {
+  1074  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "whileStmt"
+  1075  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1076  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1077  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1078  .  .  .  .  .  .  .  .  .  .  .  }
+  1079  .  .  .  .  .  .  .  .  .  .  }
+  1080  .  .  .  .  .  .  .  .  .  }
+  1081  .  .  .  .  .  .  .  .  .  3: *ast.ExprStmt {
+  1082  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1083  .  .  .  .  .  .  .  .  .  .  Expr: *ast.IncExpr {
+  1084  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1085  .  .  .  .  .  .  .  .  .  .  .  Op: "++"
+  1086  .  .  .  .  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1087  .  .  .  .  .  .  .  .  .  .  .  .  Name: "x"
+  1088  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1089  .  .  .  .  .  .  .  .  .  .  .  }
+  1090  .  .  .  .  .  .  .  .  .  .  }
+  1091  .  .  .  .  .  .  .  .  .  }
+  1092  .  .  .  .  .  .  .  .  }
+  1093  .  .  .  .  .  .  .  }
+  1094  .  .  .  .  .  .  }
+  1095  .  .  .  .  .  }
+  1096  .  .  .  .  }
+  1097  .  .  .  }
+  1098  .  .  }
+  1099  .  .  6: *ast.FuncDecl {
+  1100  .  .  .  Position: ast.Position {}
+  1101  .  .  .  Name: *ast.Ident {
+  1102  .  .  .  .  Name: "LabeledForStatement"
+  1103  .  .  .  .  Position: ast.Position {}
+  1104  .  .  .  }
+  1105  .  .  .  Type: *ast.FuncType {
+  1106  .  .  .  .  Position: ast.Position {}
+  1107  .  .  .  .  Params: *ast.FieldList {
+  1108  .  .  .  .  .  Position: ast.Position {}
+  1109  .  .  .  .  }
+  1110  .  .  .  }
+  1111  .  .  .  Body: *ast.BlockStmt {
+  1112  .  .  .  .  Position: ast.Position {}
+  1113  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1114  .  .  .  .  .  0: *ast.LabeledStatement {
+  1115  .  .  .  .  .  .  Position: ast.Position {}
+  1116  .  .  .  .  .  .  Label: *ast.Ident {
+  1117  .  .  .  .  .  .  .  Name: "outer"
+  1118  .  .  .  .  .  .  .  Position: ast.Position {}
+  1119  .  .  .  .  .  .  }
+  1120  .  .  .  .  .  .  Body: *ast.ForStatement {
+  1121  .  .  .  .  .  .  .  Position: ast.Position {}
+  1122  .  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1123  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1124  .  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1125  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1126  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1127  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1128  .  .  .  .  .  .  .  .  .  }
   1129  .  .  .  .  .  .  .  .  }
-  1130  .  .  .  .  .  .  .  }
-  1131  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1132  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1133  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1134  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1135  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  1130  .  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1131  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1132  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1133  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1134  .  .  .  .  .  .  .  .  .  .  Value: "0"
+  1135  .  .  .  .  .  .  .  .  .  }
   1136  .  .  .  .  .  .  .  .  }
   1137  .  .  .  .  .  .  .  }
-  1138  .  .  .  .  .  .  }
-  1139  .  .  .  .  .  }
-  1140  .  .  .  .  .  1: *ast.AssignStmt {
-  1141  .  .  .  .  .  .  Position: ast.Position {}
-  1142  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1143  .  .  .  .  .  .  .  0: *ast.Ident {
-  1144  .  .  .  .  .  .  .  .  Name: "fruits"
-  1145  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1146  .  .  .  .  .  .  .  }
-  1147  .  .  .  .  .  .  }
-  1148  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1149  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1150  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1151  .  .  .  .  .  .  .  .  Kind: "string"
-  1152  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1153  .  .  .  .  .  .  .  }
-  1154  .  .  .  .  .  .  }
-  1155  .  .  .  .  .  }
-  1156  .  .  .  .  .  2: *ast.SwitchStatement {
-  1157  .  .  .  .  .  .  Position: ast.Position {}
-  1158  .  .  .  .  .  .  Value: *ast.Ident {
-  1159  .  .  .  .  .  .  .  Name: "fruits"
-  1160  .  .  .  .  .  .  .  Position: ast.Position {}
-  1161  .  .  .  .  .  .  }
-  1162  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1163  .  .  .  .  .  .  .  Position: ast.Position {}
-  1164  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1165  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
-  1166  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1167  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1168  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1169  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1170  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1171  .  .  .  .  .  .  .  .  .  }
-  1172  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1173  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1174  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1175  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1176  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1177  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1178  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1179  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1180  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1181  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1182  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1183  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1184  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1185  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1186  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1187  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1188  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1189  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1190  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1191  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1192  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
-  1193  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1194  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1195  .  .  .  .  .  .  .  .  .  .  .  }
-  1196  .  .  .  .  .  .  .  .  .  .  }
-  1197  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1198  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1199  .  .  .  .  .  .  .  .  .  .  }
-  1200  .  .  .  .  .  .  .  .  .  }
-  1201  .  .  .  .  .  .  .  .  }
-  1202  .  .  .  .  .  .  .  .  1: *ast.SwitchCase {
-  1203  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1204  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1205  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1206  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1207  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
-  1208  .  .  .  .  .  .  .  .  .  }
-  1209  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1210  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1211  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1212  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1213  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1214  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1215  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1216  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1217  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1218  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1219  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1220  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1221  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1222  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1223  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1224  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1225  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1226  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1227  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1228  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1229  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
-  1230  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1231  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1232  .  .  .  .  .  .  .  .  .  .  .  }
-  1233  .  .  .  .  .  .  .  .  .  .  }
-  1234  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1235  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1236  .  .  .  .  .  .  .  .  .  .  }
-  1237  .  .  .  .  .  .  .  .  .  }
-  1238  .  .  .  .  .  .  .  .  }
-  1239  .  .  .  .  .  .  .  .  2: *ast.SwitchCase {
-  1240  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1241  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1242  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1243  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1244  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
-  1245  .  .  .  .  .  .  .  .  .  }
-  1246  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1247  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1248  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1249  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1250  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1251  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1252  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1253  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1254  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1255  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1256  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1257  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1258  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1259  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1260  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1261  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1262  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1263  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1264  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1265  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1266  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
-  1267  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1268  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1269  .  .  .  .  .  .  .  .  .  .  .  }
-  1270  .  .  .  .  .  .  .  .  .  .  }
-  1271  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1272  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1273  .  .  .  .  .  .  .  .  .  .  }
-  1274  .  .  .  .  .  .  .  .  .  }
-  1275  .  .  .  .  .  .  .  .  }
-  1276  .  .  .  .  .  .  .  .  3: *ast.SwitchDefault {
-  1277  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1278  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-  1279  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1280  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1281  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1282  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1283  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1284  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1285  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1286  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1287  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1288  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1289  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1290  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1291  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1292  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1293  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1294  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1295  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1296  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1297  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1298  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
-  1299  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1300  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1301  .  .  .  .  .  .  .  .  .  .  .  }
-  1302  .  .  .  .  .  .  .  .  .  .  }
-  1303  .  .  .  .  .  .  .  .  .  }
-  1304  .  .  .  .  .  .  .  .  }
-  1305  .  .  .  .  .  .  .  }
-  1306  .  .  .  .  .  .  }
-  1307  .  .  .  .  .  }
-  1308  .  .  .  .  .  3: *ast.ExprStmt {
-  1309  .  .  .  .  .  .  Position: ast.Position {}
-  1310  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1311  .  .  .  .  .  .  .  Position: ast.Position {}
-  1312  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1313  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1314  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1315  .  .  .  .  .  .  .  .  .  Name: "console"
-  1316  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1317  .  .  .  .  .  .  .  .  }
-  1318  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1319  .  .  .  .  .  .  .  .  .  Name: "log"
-  1320  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1321  .  .  .  .  .  .  .  .  }
-  1322  .  .  .  .  .  .  .  }
-  1323  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1324  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1325  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1326  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1327  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  1328  .  .  .  .  .  .  .  .  }
-  1329  .  .  .  .  .  .  .  }
-  1330  .  .  .  .  .  .  }
-  1331  .  .  .  .  .  }
-  1332  .  .  .  .  }
-  1333  .  .  .  }
-  1334  .  .  }
-  1335  .  .  7: *ast.FuncDecl {
-  1336  .  .  .  Position: ast.Position {}
-  1337  .  .  .  Name: *ast.Ident {
-  1338  .  .  .  .  Name: "SwitchStatementWithoutDefault"
-  1339  .  .  .  .  Position: ast.Position {}
-  1340  .  .  .  }
-  1341  .  .  .  Type: *ast.FuncType {
-  1342  .  .  .  .  Position: ast.Position {}
-  1343  .  .  .  .  Params: *ast.FieldList {
-  1344  .  .  .  .  .  Position: ast.Position {}
-  1345  .  .  .  .  }
-  1346  .  .  .  }
-  1347  .  .  .  Body: *ast.BlockStmt {
-  1348  .  .  .  .  Position: ast.Position {}
-  1349  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1350  .  .  .  .  .  0: *ast.ExprStmt {
-  1351  .  .  .  .  .  .  Position: ast.Position {}
-  1352  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1353  .  .  .  .  .  .  .  Position: ast.Position {}
-  1354  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1355  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1356  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1357  .  .  .  .  .  .  .  .  .  Name: "console"
-  1358  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1359  .  .  .  .  .  .  .  .  }
-  1360  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1361  .  .  .  .  .  .  .  .  .  Name: "log"
-  1362  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1363  .  .  .  .  .  .  .  .  }
-  1364  .  .  .  .  .  .  .  }
-  1365  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1366  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1367  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1368  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1369  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  1370  .  .  .  .  .  .  .  .  }
-  1371  .  .  .  .  .  .  .  }
-  1372  .  .  .  .  .  .  }
-  1373  .  .  .  .  .  }
-  1374  .  .  .  .  .  1: *ast.AssignStmt {
-  1375  .  .  .  .  .  .  Position: ast.Position {}
-  1376  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1377  .  .  .  .  .  .  .  0: *ast.Ident {
-  1378  .  .  .  .  .  .  .  .  Name: "fruits"
-  1379  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1380  .  .  .  .  .  .  .  }
-  1381  .  .  .  .  .  .  }
-  1382  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1383  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1384  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1385  .  .  .  .  .  .  .  .  Kind: "string"
-  1386  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1387  .  .  .  .  .  .  .  }
-  1388  .  .  .  .  .  .  }
-  1389  .  .  .  .  .  }
-  1390  .  .  .  .  .  2: *ast.SwitchStatement {
-  1391  .  .  .  .  .  .  Position: ast.Position {}
-  1392  .  .  .  .  .  .  Value: *ast.Ident {
-  1393  .  .  .  .  .  .  .  Name: "fruits"
-  1394  .  .  .  .  .  .  .  Position: ast.Position {}
-  1395  .  .  .  .  .  .  }
-  1396  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1397  .  .  .  .  .  .  .  Position: ast.Position {}
-  1398  .  .  .  .  .  .  .  List: []ast.Stmt (len = 3) {
-  1399  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
-  1400  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1401  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1402  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1403  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1404  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1405  .  .  .  .  .  .  .  .  .  }
-  1406  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1407  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1408  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1409  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1410  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1411  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1412  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1413  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1414  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1415  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1416  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1417  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1418  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1419  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1420  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1421  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1422  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1423  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1424  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1425  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1426  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
-  1427  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1428  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1429  .  .  .  .  .  .  .  .  .  .  .  }
-  1430  .  .  .  .  .  .  .  .  .  .  }
-  1431  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1432  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1433  .  .  .  .  .  .  .  .  .  .  }
-  1434  .  .  .  .  .  .  .  .  .  }
-  1435  .  .  .  .  .  .  .  .  }
-  1436  .  .  .  .  .  .  .  .  1: *ast.SwitchCase {
-  1437  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1438  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1439  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1440  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1441  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
-  1442  .  .  .  .  .  .  .  .  .  }
-  1443  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1444  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1445  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1446  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1447  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1448  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1449  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1450  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1451  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1452  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1453  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1454  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1455  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1456  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1457  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1458  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1459  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1460  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1461  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1462  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1463  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
-  1464  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1465  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1466  .  .  .  .  .  .  .  .  .  .  .  }
-  1467  .  .  .  .  .  .  .  .  .  .  }
-  1468  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1469  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1470  .  .  .  .  .  .  .  .  .  .  }
-  1471  .  .  .  .  .  .  .  .  .  }
-  1472  .  .  .  .  .  .  .  .  }
-  1473  .  .  .  .  .  .  .  .  2: *ast.SwitchCase {
-  1474  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1475  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1476  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1477  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1478  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
-  1479  .  .  .  .  .  .  .  .  .  }
-  1480  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1481  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1482  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1483  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1484  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1485  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1486  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1487  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1488  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1489  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1490  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1491  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1492  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1493  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1494  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1495  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1496  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1497  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1498  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1499  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1500  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
-  1501  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1502  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1503  .  .  .  .  .  .  .  .  .  .  .  }
-  1504  .  .  .  .  .  .  .  .  .  .  }
-  1505  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1506  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1507  .  .  .  .  .  .  .  .  .  .  }
-  1508  .  .  .  .  .  .  .  .  .  }
-  1509  .  .  .  .  .  .  .  .  }
-  1510  .  .  .  .  .  .  .  }
-  1511  .  .  .  .  .  .  }
-  1512  .  .  .  .  .  }
-  1513  .  .  .  .  .  3: *ast.ExprStmt {
-  1514  .  .  .  .  .  .  Position: ast.Position {}
-  1515  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1516  .  .  .  .  .  .  .  Position: ast.Position {}
-  1517  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1518  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1519  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1520  .  .  .  .  .  .  .  .  .  Name: "console"
-  1521  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1522  .  .  .  .  .  .  .  .  }
-  1523  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1524  .  .  .  .  .  .  .  .  .  Name: "log"
-  1525  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1526  .  .  .  .  .  .  .  .  }
-  1527  .  .  .  .  .  .  .  }
-  1528  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1529  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1530  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1531  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1532  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  1533  .  .  .  .  .  .  .  .  }
-  1534  .  .  .  .  .  .  .  }
-  1535  .  .  .  .  .  .  }
-  1536  .  .  .  .  .  }
-  1537  .  .  .  .  }
-  1538  .  .  .  }
-  1539  .  .  }
-  1540  .  .  8: *ast.FuncDecl {
-  1541  .  .  .  Position: ast.Position {}
-  1542  .  .  .  Name: *ast.Ident {
-  1543  .  .  .  .  Name: "SwitchStatementOnlyDefault"
-  1544  .  .  .  .  Position: ast.Position {}
-  1545  .  .  .  }
-  1546  .  .  .  Type: *ast.FuncType {
-  1547  .  .  .  .  Position: ast.Position {}
-  1548  .  .  .  .  Params: *ast.FieldList {
-  1549  .  .  .  .  .  Position: ast.Position {}
-  1550  .  .  .  .  }
-  1551  .  .  .  }
-  1552  .  .  .  Body: *ast.BlockStmt {
-  1553  .  .  .  .  Position: ast.Position {}
-  1554  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1555  .  .  .  .  .  0: *ast.ExprStmt {
-  1556  .  .  .  .  .  .  Position: ast.Position {}
-  1557  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1558  .  .  .  .  .  .  .  Position: ast.Position {}
-  1559  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1560  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1561  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1562  .  .  .  .  .  .  .  .  .  Name: "console"
-  1563  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1564  .  .  .  .  .  .  .  .  }
-  1565  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1566  .  .  .  .  .  .  .  .  .  Name: "log"
-  1567  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1568  .  .  .  .  .  .  .  .  }
-  1569  .  .  .  .  .  .  .  }
-  1570  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1571  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1572  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1573  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1574  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  1575  .  .  .  .  .  .  .  .  }
-  1576  .  .  .  .  .  .  .  }
-  1577  .  .  .  .  .  .  }
-  1578  .  .  .  .  .  }
-  1579  .  .  .  .  .  1: *ast.AssignStmt {
-  1580  .  .  .  .  .  .  Position: ast.Position {}
-  1581  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1582  .  .  .  .  .  .  .  0: *ast.Ident {
-  1583  .  .  .  .  .  .  .  .  Name: "fruits"
-  1584  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1585  .  .  .  .  .  .  .  }
-  1586  .  .  .  .  .  .  }
-  1587  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1588  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1589  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1590  .  .  .  .  .  .  .  .  Kind: "string"
-  1591  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1592  .  .  .  .  .  .  .  }
-  1593  .  .  .  .  .  .  }
-  1594  .  .  .  .  .  }
-  1595  .  .  .  .  .  2: *ast.SwitchStatement {
-  1596  .  .  .  .  .  .  Position: ast.Position {}
-  1597  .  .  .  .  .  .  Value: *ast.Ident {
-  1598  .  .  .  .  .  .  .  Name: "fruits"
-  1599  .  .  .  .  .  .  .  Position: ast.Position {}
-  1600  .  .  .  .  .  .  }
-  1601  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1602  .  .  .  .  .  .  .  Position: ast.Position {}
-  1603  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  1604  .  .  .  .  .  .  .  .  0: *ast.SwitchDefault {
-  1605  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1606  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-  1607  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1608  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1609  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1610  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1611  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1612  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1613  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1614  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1615  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1616  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1617  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1618  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1619  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1620  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1621  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1622  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1623  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1624  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1625  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1626  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
-  1627  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1628  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1629  .  .  .  .  .  .  .  .  .  .  .  }
-  1630  .  .  .  .  .  .  .  .  .  .  }
-  1631  .  .  .  .  .  .  .  .  .  }
-  1632  .  .  .  .  .  .  .  .  }
-  1633  .  .  .  .  .  .  .  }
-  1634  .  .  .  .  .  .  }
-  1635  .  .  .  .  .  }
-  1636  .  .  .  .  .  3: *ast.ExprStmt {
-  1637  .  .  .  .  .  .  Position: ast.Position {}
-  1638  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1639  .  .  .  .  .  .  .  Position: ast.Position {}
-  1640  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1641  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1642  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1643  .  .  .  .  .  .  .  .  .  Name: "console"
-  1644  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1645  .  .  .  .  .  .  .  .  }
-  1646  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1647  .  .  .  .  .  .  .  .  .  Name: "log"
-  1648  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1649  .  .  .  .  .  .  .  .  }
-  1650  .  .  .  .  .  .  .  }
-  1651  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1652  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1653  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1654  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1655  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  1656  .  .  .  .  .  .  .  .  }
-  1657  .  .  .  .  .  .  .  }
-  1658  .  .  .  .  .  .  }
-  1659  .  .  .  .  .  }
-  1660  .  .  .  .  }
-  1661  .  .  .  }
-  1662  .  .  }
-  1663  .  .  9: *ast.FuncDecl {
-  1664  .  .  .  Position: ast.Position {}
-  1665  .  .  .  Name: *ast.Ident {
-  1666  .  .  .  .  Name: "SwitchStatementOnlyOneCase"
-  1667  .  .  .  .  Position: ast.Position {}
-  1668  .  .  .  }
-  1669  .  .  .  Type: *ast.FuncType {
-  1670  .  .  .  .  Position: ast.Position {}
-  1671  .  .  .  .  Params: *ast.FieldList {
-  1672  .  .  .  .  .  Position: ast.Position {}
-  1673  .  .  .  .  }
-  1674  .  .  .  }
-  1675  .  .  .  Body: *ast.BlockStmt {
-  1676  .  .  .  .  Position: ast.Position {}
-  1677  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1678  .  .  .  .  .  0: *ast.ExprStmt {
-  1679  .  .  .  .  .  .  Position: ast.Position {}
-  1680  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1681  .  .  .  .  .  .  .  Position: ast.Position {}
-  1682  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1683  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1684  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1685  .  .  .  .  .  .  .  .  .  Name: "console"
-  1686  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1687  .  .  .  .  .  .  .  .  }
-  1688  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1689  .  .  .  .  .  .  .  .  .  Name: "log"
-  1690  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1691  .  .  .  .  .  .  .  .  }
-  1692  .  .  .  .  .  .  .  }
-  1693  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1694  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1695  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1696  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1697  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  1698  .  .  .  .  .  .  .  .  }
-  1699  .  .  .  .  .  .  .  }
-  1700  .  .  .  .  .  .  }
-  1701  .  .  .  .  .  }
-  1702  .  .  .  .  .  1: *ast.AssignStmt {
-  1703  .  .  .  .  .  .  Position: ast.Position {}
-  1704  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1705  .  .  .  .  .  .  .  0: *ast.Ident {
-  1706  .  .  .  .  .  .  .  .  Name: "fruits"
-  1707  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1138  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1139  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1140  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1141  .  .  .  .  .  .  .  .  .  Name: "i"
+  1142  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1143  .  .  .  .  .  .  .  .  }
+  1144  .  .  .  .  .  .  .  .  Op: "<"
+  1145  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1146  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1147  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1148  .  .  .  .  .  .  .  .  .  Value: "20"
+  1149  .  .  .  .  .  .  .  .  }
+  1150  .  .  .  .  .  .  .  }
+  1151  .  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1152  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1153  .  .  .  .  .  .  .  .  Op: "++"
+  1154  .  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1155  .  .  .  .  .  .  .  .  .  Name: "i"
+  1156  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1157  .  .  .  .  .  .  .  .  }
+  1158  .  .  .  .  .  .  .  }
+  1159  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1160  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1161  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1162  .  .  .  .  .  .  .  .  .  0: *ast.ForStatement {
+  1163  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1164  .  .  .  .  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1165  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1166  .  .  .  .  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1167  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1168  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1169  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1170  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1171  .  .  .  .  .  .  .  .  .  .  .  }
+  1172  .  .  .  .  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1173  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1174  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1175  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1176  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "0"
+  1177  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1178  .  .  .  .  .  .  .  .  .  .  .  }
+  1179  .  .  .  .  .  .  .  .  .  .  }
+  1180  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1181  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1182  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1183  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1184  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1185  .  .  .  .  .  .  .  .  .  .  .  }
+  1186  .  .  .  .  .  .  .  .  .  .  .  Op: "<"
+  1187  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1188  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1189  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1190  .  .  .  .  .  .  .  .  .  .  .  .  Value: "10"
+  1191  .  .  .  .  .  .  .  .  .  .  .  }
+  1192  .  .  .  .  .  .  .  .  .  .  }
+  1193  .  .  .  .  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1194  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1195  .  .  .  .  .  .  .  .  .  .  .  Op: "++"
+  1196  .  .  .  .  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1197  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1198  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1199  .  .  .  .  .  .  .  .  .  .  .  }
+  1200  .  .  .  .  .  .  .  .  .  .  }
+  1201  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1202  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1203  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1204  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.IfStmt {
+  1205  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1206  .  .  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1207  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1208  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1209  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1210  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1211  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1212  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: "=="
+  1213  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.Ident {
+  1214  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1215  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1216  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1217  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1218  .  .  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1219  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1220  .  .  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1221  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ContinueStatement {
+  1222  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1223  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Label: *ast.Ident {
+  1224  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "outer"
+  1225  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1226  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1227  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1228  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1229  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1230  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1231  .  .  .  .  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
+  1232  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1233  .  .  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1234  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1235  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.BinaryExpr {
+  1236  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1237  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1238  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1239  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1240  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1241  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: "/"
+  1242  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1243  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1244  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1245  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "5"
+  1246  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1247  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1248  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: ">"
+  1249  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1250  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1251  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1252  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
+  1253  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1254  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1255  .  .  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1256  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1257  .  .  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1258  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BreakStatement {
+  1259  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1260  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1261  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1262  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1263  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1264  .  .  .  .  .  .  .  .  .  .  .  }
+  1265  .  .  .  .  .  .  .  .  .  .  }
+  1266  .  .  .  .  .  .  .  .  .  }
+  1267  .  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
+  1268  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1269  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1270  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1271  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.BinaryExpr {
+  1272  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1273  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1274  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1275  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1276  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1277  .  .  .  .  .  .  .  .  .  .  .  .  Op: "%"
+  1278  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1279  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1280  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1281  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
+  1282  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1283  .  .  .  .  .  .  .  .  .  .  .  }
+  1284  .  .  .  .  .  .  .  .  .  .  .  Op: "==="
+  1285  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1286  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1287  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1288  .  .  .  .  .  .  .  .  .  .  .  .  Value: "0"
+  1289  .  .  .  .  .  .  .  .  .  .  .  }
+  1290  .  .  .  .  .  .  .  .  .  .  }
+  1291  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1292  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1293  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1294  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BreakStatement {
+  1295  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1296  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1297  .  .  .  .  .  .  .  .  .  .  .  }
+  1298  .  .  .  .  .  .  .  .  .  .  }
+  1299  .  .  .  .  .  .  .  .  .  }
+  1300  .  .  .  .  .  .  .  .  }
+  1301  .  .  .  .  .  .  .  }
+  1302  .  .  .  .  .  .  }
+  1303  .  .  .  .  .  }
+  1304  .  .  .  .  }
+  1305  .  .  .  }
+  1306  .  .  }
+  1307  .  .  7: *ast.FuncDecl {
+  1308  .  .  .  Position: ast.Position {}
+  1309  .  .  .  Name: *ast.Ident {
+  1310  .  .  .  .  Name: "NestedForStatement"
+  1311  .  .  .  .  Position: ast.Position {}
+  1312  .  .  .  }
+  1313  .  .  .  Type: *ast.FuncType {
+  1314  .  .  .  .  Position: ast.Position {}
+  1315  .  .  .  .  Params: *ast.FieldList {
+  1316  .  .  .  .  .  Position: ast.Position {}
+  1317  .  .  .  .  }
+  1318  .  .  .  }
+  1319  .  .  .  Body: *ast.BlockStmt {
+  1320  .  .  .  .  Position: ast.Position {}
+  1321  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1322  .  .  .  .  .  0: *ast.ForStatement {
+  1323  .  .  .  .  .  .  Position: ast.Position {}
+  1324  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1325  .  .  .  .  .  .  .  Position: ast.Position {}
+  1326  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1327  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1328  .  .  .  .  .  .  .  .  .  Name: "i"
+  1329  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1330  .  .  .  .  .  .  .  .  }
+  1331  .  .  .  .  .  .  .  }
+  1332  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1333  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1334  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1335  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1336  .  .  .  .  .  .  .  .  .  Value: "0"
+  1337  .  .  .  .  .  .  .  .  }
+  1338  .  .  .  .  .  .  .  }
+  1339  .  .  .  .  .  .  }
+  1340  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1341  .  .  .  .  .  .  .  Position: ast.Position {}
+  1342  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1343  .  .  .  .  .  .  .  .  Name: "i"
+  1344  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1345  .  .  .  .  .  .  .  }
+  1346  .  .  .  .  .  .  .  Op: "<"
+  1347  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1348  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1349  .  .  .  .  .  .  .  .  Kind: "number"
+  1350  .  .  .  .  .  .  .  .  Value: "20"
+  1351  .  .  .  .  .  .  .  }
+  1352  .  .  .  .  .  .  }
+  1353  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1354  .  .  .  .  .  .  .  Position: ast.Position {}
+  1355  .  .  .  .  .  .  .  Op: "++"
+  1356  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1357  .  .  .  .  .  .  .  .  Name: "i"
+  1358  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1359  .  .  .  .  .  .  .  }
+  1360  .  .  .  .  .  .  }
+  1361  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1362  .  .  .  .  .  .  .  Position: ast.Position {}
+  1363  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1364  .  .  .  .  .  .  .  .  0: *ast.ForStatement {
+  1365  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1366  .  .  .  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  1367  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1368  .  .  .  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1369  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  1370  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1371  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1372  .  .  .  .  .  .  .  .  .  .  .  }
+  1373  .  .  .  .  .  .  .  .  .  .  }
+  1374  .  .  .  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1375  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1376  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1377  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1378  .  .  .  .  .  .  .  .  .  .  .  .  Value: "0"
+  1379  .  .  .  .  .  .  .  .  .  .  .  }
+  1380  .  .  .  .  .  .  .  .  .  .  }
+  1381  .  .  .  .  .  .  .  .  .  }
+  1382  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1383  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1384  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1385  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1386  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1387  .  .  .  .  .  .  .  .  .  .  }
+  1388  .  .  .  .  .  .  .  .  .  .  Op: "<"
+  1389  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1390  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1391  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1392  .  .  .  .  .  .  .  .  .  .  .  Value: "10"
+  1393  .  .  .  .  .  .  .  .  .  .  }
+  1394  .  .  .  .  .  .  .  .  .  }
+  1395  .  .  .  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  1396  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1397  .  .  .  .  .  .  .  .  .  .  Op: "++"
+  1398  .  .  .  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  1399  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1400  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1401  .  .  .  .  .  .  .  .  .  .  }
+  1402  .  .  .  .  .  .  .  .  .  }
+  1403  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1404  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1405  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  1406  .  .  .  .  .  .  .  .  .  .  .  0: *ast.IfStmt {
+  1407  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1408  .  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1409  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1410  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1411  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1412  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1413  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1414  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: "=="
+  1415  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.Ident {
+  1416  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1417  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1418  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1419  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1420  .  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1421  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1422  .  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1423  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.ContinueStatement {
+  1424  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1425  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1426  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1427  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1428  .  .  .  .  .  .  .  .  .  .  .  }
+  1429  .  .  .  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
+  1430  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1431  .  .  .  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1432  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1433  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.BinaryExpr {
+  1434  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1435  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1436  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "j"
+  1437  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1438  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1439  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: "/"
+  1440  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1441  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1442  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1443  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "5"
+  1444  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1445  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1446  .  .  .  .  .  .  .  .  .  .  .  .  .  Op: ">"
+  1447  .  .  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1448  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1449  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1450  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
+  1451  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1452  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1453  .  .  .  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1454  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1455  .  .  .  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1456  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BreakStatement {
+  1457  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1458  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1459  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1460  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1461  .  .  .  .  .  .  .  .  .  .  .  }
+  1462  .  .  .  .  .  .  .  .  .  .  }
+  1463  .  .  .  .  .  .  .  .  .  }
+  1464  .  .  .  .  .  .  .  .  }
+  1465  .  .  .  .  .  .  .  .  1: *ast.IfStmt {
+  1466  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1467  .  .  .  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  1468  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1469  .  .  .  .  .  .  .  .  .  .  Left: *ast.BinaryExpr {
+  1470  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1471  .  .  .  .  .  .  .  .  .  .  .  Left: *ast.Ident {
+  1472  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  1473  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1474  .  .  .  .  .  .  .  .  .  .  .  }
+  1475  .  .  .  .  .  .  .  .  .  .  .  Op: "%"
+  1476  .  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1477  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1478  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1479  .  .  .  .  .  .  .  .  .  .  .  .  Value: "2"
+  1480  .  .  .  .  .  .  .  .  .  .  .  }
+  1481  .  .  .  .  .  .  .  .  .  .  }
+  1482  .  .  .  .  .  .  .  .  .  .  Op: "==="
+  1483  .  .  .  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  1484  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1485  .  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  1486  .  .  .  .  .  .  .  .  .  .  .  Value: "0"
+  1487  .  .  .  .  .  .  .  .  .  .  }
+  1488  .  .  .  .  .  .  .  .  .  }
+  1489  .  .  .  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1490  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1491  .  .  .  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  1492  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BreakStatement {
+  1493  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1494  .  .  .  .  .  .  .  .  .  .  .  }
+  1495  .  .  .  .  .  .  .  .  .  .  }
+  1496  .  .  .  .  .  .  .  .  .  }
+  1497  .  .  .  .  .  .  .  .  }
+  1498  .  .  .  .  .  .  .  }
+  1499  .  .  .  .  .  .  }
+  1500  .  .  .  .  .  }
+  1501  .  .  .  .  }
+  1502  .  .  .  }
+  1503  .  .  }
+  1504  .  .  8: *ast.FuncDecl {
+  1505  .  .  .  Position: ast.Position {}
+  1506  .  .  .  Name: *ast.Ident {
+  1507  .  .  .  .  Name: "SwitchStatement"
+  1508  .  .  .  .  Position: ast.Position {}
+  1509  .  .  .  }
+  1510  .  .  .  Type: *ast.FuncType {
+  1511  .  .  .  .  Position: ast.Position {}
+  1512  .  .  .  .  Params: *ast.FieldList {
+  1513  .  .  .  .  .  Position: ast.Position {}
+  1514  .  .  .  .  }
+  1515  .  .  .  }
+  1516  .  .  .  Body: *ast.BlockStmt {
+  1517  .  .  .  .  Position: ast.Position {}
+  1518  .  .  .  .  List: []ast.Stmt (len = 4) {
+  1519  .  .  .  .  .  0: *ast.ExprStmt {
+  1520  .  .  .  .  .  .  Position: ast.Position {}
+  1521  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1522  .  .  .  .  .  .  .  Position: ast.Position {}
+  1523  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1524  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1525  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1526  .  .  .  .  .  .  .  .  .  Name: "console"
+  1527  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1528  .  .  .  .  .  .  .  .  }
+  1529  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1530  .  .  .  .  .  .  .  .  .  Name: "log"
+  1531  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1532  .  .  .  .  .  .  .  .  }
+  1533  .  .  .  .  .  .  .  }
+  1534  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1535  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1536  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1537  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1538  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  1539  .  .  .  .  .  .  .  .  }
+  1540  .  .  .  .  .  .  .  }
+  1541  .  .  .  .  .  .  }
+  1542  .  .  .  .  .  }
+  1543  .  .  .  .  .  1: *ast.AssignStmt {
+  1544  .  .  .  .  .  .  Position: ast.Position {}
+  1545  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1546  .  .  .  .  .  .  .  0: *ast.Ident {
+  1547  .  .  .  .  .  .  .  .  Name: "fruits"
+  1548  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1549  .  .  .  .  .  .  .  }
+  1550  .  .  .  .  .  .  }
+  1551  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1552  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1553  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1554  .  .  .  .  .  .  .  .  Kind: "string"
+  1555  .  .  .  .  .  .  .  .  Value: "Oranges"
+  1556  .  .  .  .  .  .  .  }
+  1557  .  .  .  .  .  .  }
+  1558  .  .  .  .  .  }
+  1559  .  .  .  .  .  2: *ast.SwitchStatement {
+  1560  .  .  .  .  .  .  Position: ast.Position {}
+  1561  .  .  .  .  .  .  Value: *ast.Ident {
+  1562  .  .  .  .  .  .  .  Name: "fruits"
+  1563  .  .  .  .  .  .  .  Position: ast.Position {}
+  1564  .  .  .  .  .  .  }
+  1565  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1566  .  .  .  .  .  .  .  Position: ast.Position {}
+  1567  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
+  1568  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
+  1569  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1570  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1571  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1572  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1573  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
+  1574  .  .  .  .  .  .  .  .  .  }
+  1575  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1576  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1577  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1578  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1579  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1580  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1581  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1582  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1583  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1584  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1585  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1586  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1587  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1588  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1589  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1590  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1591  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1592  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1593  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1594  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1595  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
+  1596  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1597  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1598  .  .  .  .  .  .  .  .  .  .  .  }
+  1599  .  .  .  .  .  .  .  .  .  .  }
+  1600  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1601  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1602  .  .  .  .  .  .  .  .  .  .  }
+  1603  .  .  .  .  .  .  .  .  .  }
+  1604  .  .  .  .  .  .  .  .  }
+  1605  .  .  .  .  .  .  .  .  1: *ast.SwitchCase {
+  1606  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1607  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1608  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1609  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1610  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
+  1611  .  .  .  .  .  .  .  .  .  }
+  1612  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1613  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1614  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1615  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1616  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1617  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1618  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1619  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1620  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1621  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1622  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1623  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1624  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1625  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1626  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1627  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1628  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1629  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1630  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1631  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1632  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
+  1633  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1634  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1635  .  .  .  .  .  .  .  .  .  .  .  }
+  1636  .  .  .  .  .  .  .  .  .  .  }
+  1637  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1638  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1639  .  .  .  .  .  .  .  .  .  .  }
+  1640  .  .  .  .  .  .  .  .  .  }
+  1641  .  .  .  .  .  .  .  .  }
+  1642  .  .  .  .  .  .  .  .  2: *ast.SwitchCase {
+  1643  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1644  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1645  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1646  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1647  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
+  1648  .  .  .  .  .  .  .  .  .  }
+  1649  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1650  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1651  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1652  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1653  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1654  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1655  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1656  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1657  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1658  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1659  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1660  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1661  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1662  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1663  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1664  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1665  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1666  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1667  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1668  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1669  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
+  1670  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1671  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1672  .  .  .  .  .  .  .  .  .  .  .  }
+  1673  .  .  .  .  .  .  .  .  .  .  }
+  1674  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1675  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1676  .  .  .  .  .  .  .  .  .  .  }
+  1677  .  .  .  .  .  .  .  .  .  }
+  1678  .  .  .  .  .  .  .  .  }
+  1679  .  .  .  .  .  .  .  .  3: *ast.SwitchDefault {
+  1680  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1681  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
+  1682  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1683  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1684  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1685  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1686  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1687  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1688  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1689  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1690  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1691  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1692  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1693  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1694  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1695  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1696  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1697  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1698  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1699  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1700  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1701  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
+  1702  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1703  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1704  .  .  .  .  .  .  .  .  .  .  .  }
+  1705  .  .  .  .  .  .  .  .  .  .  }
+  1706  .  .  .  .  .  .  .  .  .  }
+  1707  .  .  .  .  .  .  .  .  }
   1708  .  .  .  .  .  .  .  }
   1709  .  .  .  .  .  .  }
-  1710  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1711  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1712  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1713  .  .  .  .  .  .  .  .  Kind: "string"
-  1714  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1715  .  .  .  .  .  .  .  }
-  1716  .  .  .  .  .  .  }
-  1717  .  .  .  .  .  }
-  1718  .  .  .  .  .  2: *ast.SwitchStatement {
-  1719  .  .  .  .  .  .  Position: ast.Position {}
-  1720  .  .  .  .  .  .  Value: *ast.Ident {
-  1721  .  .  .  .  .  .  .  Name: "fruits"
-  1722  .  .  .  .  .  .  .  Position: ast.Position {}
-  1723  .  .  .  .  .  .  }
-  1724  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1725  .  .  .  .  .  .  .  Position: ast.Position {}
-  1726  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  1727  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
+  1710  .  .  .  .  .  }
+  1711  .  .  .  .  .  3: *ast.ExprStmt {
+  1712  .  .  .  .  .  .  Position: ast.Position {}
+  1713  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1714  .  .  .  .  .  .  .  Position: ast.Position {}
+  1715  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1716  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1717  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1718  .  .  .  .  .  .  .  .  .  Name: "console"
+  1719  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1720  .  .  .  .  .  .  .  .  }
+  1721  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1722  .  .  .  .  .  .  .  .  .  Name: "log"
+  1723  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1724  .  .  .  .  .  .  .  .  }
+  1725  .  .  .  .  .  .  .  }
+  1726  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1727  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
   1728  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1729  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  1730  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1731  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1732  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1733  .  .  .  .  .  .  .  .  .  }
-  1734  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  1735  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1736  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1737  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1738  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1739  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1740  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1741  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1742  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1743  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1744  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1745  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1746  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1747  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1748  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1749  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1750  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1751  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1752  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1753  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1754  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
-  1755  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1756  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1757  .  .  .  .  .  .  .  .  .  .  .  }
-  1758  .  .  .  .  .  .  .  .  .  .  }
-  1759  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  1760  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1761  .  .  .  .  .  .  .  .  .  .  }
-  1762  .  .  .  .  .  .  .  .  .  }
-  1763  .  .  .  .  .  .  .  .  }
-  1764  .  .  .  .  .  .  .  }
-  1765  .  .  .  .  .  .  }
-  1766  .  .  .  .  .  }
-  1767  .  .  .  .  .  3: *ast.ExprStmt {
-  1768  .  .  .  .  .  .  Position: ast.Position {}
-  1769  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1770  .  .  .  .  .  .  .  Position: ast.Position {}
-  1771  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1772  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1773  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1774  .  .  .  .  .  .  .  .  .  Name: "console"
-  1775  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1776  .  .  .  .  .  .  .  .  }
-  1777  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1778  .  .  .  .  .  .  .  .  .  Name: "log"
-  1779  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1780  .  .  .  .  .  .  .  .  }
-  1781  .  .  .  .  .  .  .  }
-  1782  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1783  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1784  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1785  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1786  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  1787  .  .  .  .  .  .  .  .  }
-  1788  .  .  .  .  .  .  .  }
-  1789  .  .  .  .  .  .  }
-  1790  .  .  .  .  .  }
-  1791  .  .  .  .  }
-  1792  .  .  .  }
-  1793  .  .  }
-  1794  .  .  10: *ast.FuncDecl {
-  1795  .  .  .  Position: ast.Position {}
-  1796  .  .  .  Name: *ast.Ident {
-  1797  .  .  .  .  Name: "SwitchStatementWithBadNodesAndDefault"
-  1798  .  .  .  .  Position: ast.Position {}
-  1799  .  .  .  }
-  1800  .  .  .  Type: *ast.FuncType {
-  1801  .  .  .  .  Position: ast.Position {}
-  1802  .  .  .  .  Params: *ast.FieldList {
-  1803  .  .  .  .  .  Position: ast.Position {}
-  1804  .  .  .  .  }
-  1805  .  .  .  }
-  1806  .  .  .  Body: *ast.BlockStmt {
-  1807  .  .  .  .  Position: ast.Position {}
-  1808  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1809  .  .  .  .  .  0: *ast.ExprStmt {
-  1810  .  .  .  .  .  .  Position: ast.Position {}
-  1811  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1812  .  .  .  .  .  .  .  Position: ast.Position {}
-  1813  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1814  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1815  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1816  .  .  .  .  .  .  .  .  .  Name: "console"
-  1817  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1818  .  .  .  .  .  .  .  .  }
-  1819  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1820  .  .  .  .  .  .  .  .  .  Name: "log"
-  1821  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1822  .  .  .  .  .  .  .  .  }
-  1823  .  .  .  .  .  .  .  }
-  1824  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1825  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1826  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1827  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1828  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  1829  .  .  .  .  .  .  .  .  }
-  1830  .  .  .  .  .  .  .  }
-  1831  .  .  .  .  .  .  }
-  1832  .  .  .  .  .  }
-  1833  .  .  .  .  .  1: *ast.AssignStmt {
-  1834  .  .  .  .  .  .  Position: ast.Position {}
-  1835  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1836  .  .  .  .  .  .  .  0: *ast.Ident {
-  1837  .  .  .  .  .  .  .  .  Name: "fruits"
-  1838  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1839  .  .  .  .  .  .  .  }
-  1840  .  .  .  .  .  .  }
-  1841  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1842  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1843  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1844  .  .  .  .  .  .  .  .  Kind: "string"
-  1845  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1846  .  .  .  .  .  .  .  }
-  1847  .  .  .  .  .  .  }
-  1848  .  .  .  .  .  }
-  1849  .  .  .  .  .  2: *ast.SwitchStatement {
-  1850  .  .  .  .  .  .  Position: ast.Position {}
-  1851  .  .  .  .  .  .  Value: *ast.Ident {
-  1852  .  .  .  .  .  .  .  Name: "fruits"
-  1853  .  .  .  .  .  .  .  Position: ast.Position {}
-  1854  .  .  .  .  .  .  }
-  1855  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1856  .  .  .  .  .  .  .  Position: ast.Position {}
-  1857  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1858  .  .  .  .  .  .  .  .  0: *ast.BadNode {
-  1859  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1860  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  1861  .  .  .  .  .  .  .  .  }
-  1862  .  .  .  .  .  .  .  .  1: *ast.BadNode {
-  1863  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1864  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  1865  .  .  .  .  .  .  .  .  }
-  1866  .  .  .  .  .  .  .  .  2: *ast.BadNode {
-  1867  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1868  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  1869  .  .  .  .  .  .  .  .  }
-  1870  .  .  .  .  .  .  .  .  3: *ast.SwitchDefault {
-  1871  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1872  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-  1873  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  1874  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1875  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1876  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1877  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1878  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1879  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1880  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  1881  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1882  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1883  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1884  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  1885  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1886  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1887  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1888  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1889  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1890  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1891  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1892  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
+  1729  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1730  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  1731  .  .  .  .  .  .  .  .  }
+  1732  .  .  .  .  .  .  .  }
+  1733  .  .  .  .  .  .  }
+  1734  .  .  .  .  .  }
+  1735  .  .  .  .  }
+  1736  .  .  .  }
+  1737  .  .  }
+  1738  .  .  9: *ast.FuncDecl {
+  1739  .  .  .  Position: ast.Position {}
+  1740  .  .  .  Name: *ast.Ident {
+  1741  .  .  .  .  Name: "SwitchStatementWithoutDefault"
+  1742  .  .  .  .  Position: ast.Position {}
+  1743  .  .  .  }
+  1744  .  .  .  Type: *ast.FuncType {
+  1745  .  .  .  .  Position: ast.Position {}
+  1746  .  .  .  .  Params: *ast.FieldList {
+  1747  .  .  .  .  .  Position: ast.Position {}
+  1748  .  .  .  .  }
+  1749  .  .  .  }
+  1750  .  .  .  Body: *ast.BlockStmt {
+  1751  .  .  .  .  Position: ast.Position {}
+  1752  .  .  .  .  List: []ast.Stmt (len = 4) {
+  1753  .  .  .  .  .  0: *ast.ExprStmt {
+  1754  .  .  .  .  .  .  Position: ast.Position {}
+  1755  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1756  .  .  .  .  .  .  .  Position: ast.Position {}
+  1757  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1758  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1759  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1760  .  .  .  .  .  .  .  .  .  Name: "console"
+  1761  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1762  .  .  .  .  .  .  .  .  }
+  1763  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1764  .  .  .  .  .  .  .  .  .  Name: "log"
+  1765  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1766  .  .  .  .  .  .  .  .  }
+  1767  .  .  .  .  .  .  .  }
+  1768  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1769  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1770  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1771  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1772  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  1773  .  .  .  .  .  .  .  .  }
+  1774  .  .  .  .  .  .  .  }
+  1775  .  .  .  .  .  .  }
+  1776  .  .  .  .  .  }
+  1777  .  .  .  .  .  1: *ast.AssignStmt {
+  1778  .  .  .  .  .  .  Position: ast.Position {}
+  1779  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1780  .  .  .  .  .  .  .  0: *ast.Ident {
+  1781  .  .  .  .  .  .  .  .  Name: "fruits"
+  1782  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1783  .  .  .  .  .  .  .  }
+  1784  .  .  .  .  .  .  }
+  1785  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1786  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1787  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1788  .  .  .  .  .  .  .  .  Kind: "string"
+  1789  .  .  .  .  .  .  .  .  Value: "Oranges"
+  1790  .  .  .  .  .  .  .  }
+  1791  .  .  .  .  .  .  }
+  1792  .  .  .  .  .  }
+  1793  .  .  .  .  .  2: *ast.SwitchStatement {
+  1794  .  .  .  .  .  .  Position: ast.Position {}
+  1795  .  .  .  .  .  .  Value: *ast.Ident {
+  1796  .  .  .  .  .  .  .  Name: "fruits"
+  1797  .  .  .  .  .  .  .  Position: ast.Position {}
+  1798  .  .  .  .  .  .  }
+  1799  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  1800  .  .  .  .  .  .  .  Position: ast.Position {}
+  1801  .  .  .  .  .  .  .  List: []ast.Stmt (len = 3) {
+  1802  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
+  1803  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1804  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1805  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1806  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1807  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
+  1808  .  .  .  .  .  .  .  .  .  }
+  1809  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1810  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1811  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1812  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1813  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1814  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1815  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1816  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1817  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1818  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1819  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1820  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1821  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1822  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1823  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1824  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1825  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1826  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1827  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1828  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1829  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
+  1830  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1831  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1832  .  .  .  .  .  .  .  .  .  .  .  }
+  1833  .  .  .  .  .  .  .  .  .  .  }
+  1834  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1835  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1836  .  .  .  .  .  .  .  .  .  .  }
+  1837  .  .  .  .  .  .  .  .  .  }
+  1838  .  .  .  .  .  .  .  .  }
+  1839  .  .  .  .  .  .  .  .  1: *ast.SwitchCase {
+  1840  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1841  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1842  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1843  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1844  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
+  1845  .  .  .  .  .  .  .  .  .  }
+  1846  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1847  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1848  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1849  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1850  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1851  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1852  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1853  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1854  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1855  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1856  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1857  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1858  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1859  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1860  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1861  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1862  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1863  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1864  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1865  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1866  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
+  1867  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1868  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1869  .  .  .  .  .  .  .  .  .  .  .  }
+  1870  .  .  .  .  .  .  .  .  .  .  }
+  1871  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1872  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1873  .  .  .  .  .  .  .  .  .  .  }
+  1874  .  .  .  .  .  .  .  .  .  }
+  1875  .  .  .  .  .  .  .  .  }
+  1876  .  .  .  .  .  .  .  .  2: *ast.SwitchCase {
+  1877  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1878  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  1879  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1880  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1881  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
+  1882  .  .  .  .  .  .  .  .  .  }
+  1883  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  1884  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  1885  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1886  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1887  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1888  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1889  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1890  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1891  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  1892  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
   1893  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1894  .  .  .  .  .  .  .  .  .  .  .  .  }
-  1895  .  .  .  .  .  .  .  .  .  .  .  }
-  1896  .  .  .  .  .  .  .  .  .  .  }
-  1897  .  .  .  .  .  .  .  .  .  }
-  1898  .  .  .  .  .  .  .  .  }
-  1899  .  .  .  .  .  .  .  }
-  1900  .  .  .  .  .  .  }
-  1901  .  .  .  .  .  }
-  1902  .  .  .  .  .  3: *ast.ExprStmt {
-  1903  .  .  .  .  .  .  Position: ast.Position {}
-  1904  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1905  .  .  .  .  .  .  .  Position: ast.Position {}
-  1906  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1907  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1908  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1909  .  .  .  .  .  .  .  .  .  Name: "console"
-  1910  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1911  .  .  .  .  .  .  .  .  }
-  1912  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1913  .  .  .  .  .  .  .  .  .  Name: "log"
-  1914  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1915  .  .  .  .  .  .  .  .  }
-  1916  .  .  .  .  .  .  .  }
-  1917  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1918  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1919  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1920  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1921  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  1922  .  .  .  .  .  .  .  .  }
-  1923  .  .  .  .  .  .  .  }
-  1924  .  .  .  .  .  .  }
-  1925  .  .  .  .  .  }
-  1926  .  .  .  .  }
-  1927  .  .  .  }
-  1928  .  .  }
-  1929  .  .  11: *ast.FuncDecl {
-  1930  .  .  .  Position: ast.Position {}
-  1931  .  .  .  Name: *ast.Ident {
-  1932  .  .  .  .  Name: "SwitchStatementWithBadNode"
-  1933  .  .  .  .  Position: ast.Position {}
-  1934  .  .  .  }
-  1935  .  .  .  Type: *ast.FuncType {
-  1936  .  .  .  .  Position: ast.Position {}
-  1937  .  .  .  .  Params: *ast.FieldList {
-  1938  .  .  .  .  .  Position: ast.Position {}
-  1939  .  .  .  .  }
-  1940  .  .  .  }
-  1941  .  .  .  Body: *ast.BlockStmt {
-  1942  .  .  .  .  Position: ast.Position {}
-  1943  .  .  .  .  List: []ast.Stmt (len = 4) {
-  1944  .  .  .  .  .  0: *ast.ExprStmt {
-  1945  .  .  .  .  .  .  Position: ast.Position {}
-  1946  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  1947  .  .  .  .  .  .  .  Position: ast.Position {}
-  1948  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  1949  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1950  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  1951  .  .  .  .  .  .  .  .  .  Name: "console"
-  1952  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1953  .  .  .  .  .  .  .  .  }
-  1954  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  1955  .  .  .  .  .  .  .  .  .  Name: "log"
-  1956  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1957  .  .  .  .  .  .  .  .  }
-  1958  .  .  .  .  .  .  .  }
-  1959  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  1960  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1961  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1962  .  .  .  .  .  .  .  .  .  Kind: "string"
-  1963  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  1964  .  .  .  .  .  .  .  .  }
-  1965  .  .  .  .  .  .  .  }
-  1966  .  .  .  .  .  .  }
-  1967  .  .  .  .  .  }
-  1968  .  .  .  .  .  1: *ast.AssignStmt {
-  1969  .  .  .  .  .  .  Position: ast.Position {}
-  1970  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  1971  .  .  .  .  .  .  .  0: *ast.Ident {
-  1972  .  .  .  .  .  .  .  .  Name: "fruits"
-  1973  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1974  .  .  .  .  .  .  .  }
-  1975  .  .  .  .  .  .  }
-  1976  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  1977  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  1978  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1979  .  .  .  .  .  .  .  .  Kind: "string"
-  1980  .  .  .  .  .  .  .  .  Value: "Oranges"
-  1981  .  .  .  .  .  .  .  }
-  1982  .  .  .  .  .  .  }
-  1983  .  .  .  .  .  }
-  1984  .  .  .  .  .  2: *ast.SwitchStatement {
-  1985  .  .  .  .  .  .  Position: ast.Position {}
-  1986  .  .  .  .  .  .  Value: *ast.Ident {
-  1987  .  .  .  .  .  .  .  Name: "fruits"
-  1988  .  .  .  .  .  .  .  Position: ast.Position {}
+  1894  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1895  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  1896  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1897  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1898  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1899  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1900  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1901  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1902  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1903  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
+  1904  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1905  .  .  .  .  .  .  .  .  .  .  .  .  }
+  1906  .  .  .  .  .  .  .  .  .  .  .  }
+  1907  .  .  .  .  .  .  .  .  .  .  }
+  1908  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  1909  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1910  .  .  .  .  .  .  .  .  .  .  }
+  1911  .  .  .  .  .  .  .  .  .  }
+  1912  .  .  .  .  .  .  .  .  }
+  1913  .  .  .  .  .  .  .  }
+  1914  .  .  .  .  .  .  }
+  1915  .  .  .  .  .  }
+  1916  .  .  .  .  .  3: *ast.ExprStmt {
+  1917  .  .  .  .  .  .  Position: ast.Position {}
+  1918  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1919  .  .  .  .  .  .  .  Position: ast.Position {}
+  1920  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1921  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1922  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1923  .  .  .  .  .  .  .  .  .  Name: "console"
+  1924  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1925  .  .  .  .  .  .  .  .  }
+  1926  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1927  .  .  .  .  .  .  .  .  .  Name: "log"
+  1928  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1929  .  .  .  .  .  .  .  .  }
+  1930  .  .  .  .  .  .  .  }
+  1931  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1932  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1933  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1934  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1935  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  1936  .  .  .  .  .  .  .  .  }
+  1937  .  .  .  .  .  .  .  }
+  1938  .  .  .  .  .  .  }
+  1939  .  .  .  .  .  }
+  1940  .  .  .  .  }
+  1941  .  .  .  }
+  1942  .  .  }
+  1943  .  .  10: *ast.FuncDecl {
+  1944  .  .  .  Position: ast.Position {}
+  1945  .  .  .  Name: *ast.Ident {
+  1946  .  .  .  .  Name: "SwitchStatementOnlyDefault"
+  1947  .  .  .  .  Position: ast.Position {}
+  1948  .  .  .  }
+  1949  .  .  .  Type: *ast.FuncType {
+  1950  .  .  .  .  Position: ast.Position {}
+  1951  .  .  .  .  Params: *ast.FieldList {
+  1952  .  .  .  .  .  Position: ast.Position {}
+  1953  .  .  .  .  }
+  1954  .  .  .  }
+  1955  .  .  .  Body: *ast.BlockStmt {
+  1956  .  .  .  .  Position: ast.Position {}
+  1957  .  .  .  .  List: []ast.Stmt (len = 4) {
+  1958  .  .  .  .  .  0: *ast.ExprStmt {
+  1959  .  .  .  .  .  .  Position: ast.Position {}
+  1960  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  1961  .  .  .  .  .  .  .  Position: ast.Position {}
+  1962  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  1963  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1964  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  1965  .  .  .  .  .  .  .  .  .  Name: "console"
+  1966  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1967  .  .  .  .  .  .  .  .  }
+  1968  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  1969  .  .  .  .  .  .  .  .  .  Name: "log"
+  1970  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1971  .  .  .  .  .  .  .  .  }
+  1972  .  .  .  .  .  .  .  }
+  1973  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  1974  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1975  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1976  .  .  .  .  .  .  .  .  .  Kind: "string"
+  1977  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  1978  .  .  .  .  .  .  .  .  }
+  1979  .  .  .  .  .  .  .  }
+  1980  .  .  .  .  .  .  }
+  1981  .  .  .  .  .  }
+  1982  .  .  .  .  .  1: *ast.AssignStmt {
+  1983  .  .  .  .  .  .  Position: ast.Position {}
+  1984  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  1985  .  .  .  .  .  .  .  0: *ast.Ident {
+  1986  .  .  .  .  .  .  .  .  Name: "fruits"
+  1987  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1988  .  .  .  .  .  .  .  }
   1989  .  .  .  .  .  .  }
-  1990  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  1991  .  .  .  .  .  .  .  Position: ast.Position {}
-  1992  .  .  .  .  .  .  .  List: []ast.Stmt (len = 5) {
-  1993  .  .  .  .  .  .  .  .  0: *ast.BadNode {
-  1994  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1995  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  1996  .  .  .  .  .  .  .  .  }
-  1997  .  .  .  .  .  .  .  .  1: *ast.BadNode {
-  1998  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  1999  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  2000  .  .  .  .  .  .  .  .  }
-  2001  .  .  .  .  .  .  .  .  2: *ast.BadNode {
-  2002  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2003  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
-  2004  .  .  .  .  .  .  .  .  }
-  2005  .  .  .  .  .  .  .  .  3: *ast.SwitchCase {
-  2006  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2007  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  2008  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2009  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2010  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
-  2011  .  .  .  .  .  .  .  .  .  }
-  2012  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  2013  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2014  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2015  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2016  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2017  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2018  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2019  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2020  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2021  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2022  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2023  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2024  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2025  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2026  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2027  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2028  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2029  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2030  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2031  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2032  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
-  2033  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2034  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2035  .  .  .  .  .  .  .  .  .  .  .  }
-  2036  .  .  .  .  .  .  .  .  .  .  }
-  2037  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  2038  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2039  .  .  .  .  .  .  .  .  .  .  }
-  2040  .  .  .  .  .  .  .  .  .  }
-  2041  .  .  .  .  .  .  .  .  }
-  2042  .  .  .  .  .  .  .  .  4: *ast.SwitchCase {
-  2043  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2044  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  2045  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2046  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2047  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
-  2048  .  .  .  .  .  .  .  .  .  }
-  2049  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
-  2050  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2051  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2052  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2053  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2054  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2055  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2056  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2057  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2058  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2059  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2060  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2061  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2062  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2063  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2064  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2065  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2066  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2067  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2068  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2069  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
-  2070  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2071  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2072  .  .  .  .  .  .  .  .  .  .  .  }
-  2073  .  .  .  .  .  .  .  .  .  .  }
-  2074  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
-  2075  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2076  .  .  .  .  .  .  .  .  .  .  }
-  2077  .  .  .  .  .  .  .  .  .  }
-  2078  .  .  .  .  .  .  .  .  }
-  2079  .  .  .  .  .  .  .  }
-  2080  .  .  .  .  .  .  }
-  2081  .  .  .  .  .  }
-  2082  .  .  .  .  .  3: *ast.ExprStmt {
-  2083  .  .  .  .  .  .  Position: ast.Position {}
-  2084  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2085  .  .  .  .  .  .  .  Position: ast.Position {}
-  2086  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2087  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2088  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2089  .  .  .  .  .  .  .  .  .  Name: "console"
-  2090  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2091  .  .  .  .  .  .  .  .  }
-  2092  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2093  .  .  .  .  .  .  .  .  .  Name: "log"
-  2094  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2095  .  .  .  .  .  .  .  .  }
-  2096  .  .  .  .  .  .  .  }
-  2097  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2098  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2099  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2100  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2101  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  2102  .  .  .  .  .  .  .  .  }
-  2103  .  .  .  .  .  .  .  }
-  2104  .  .  .  .  .  .  }
-  2105  .  .  .  .  .  }
-  2106  .  .  .  .  }
-  2107  .  .  .  }
-  2108  .  .  }
-  2109  .  .  12: *ast.FuncDecl {
-  2110  .  .  .  Position: ast.Position {}
-  2111  .  .  .  Name: *ast.Ident {
-  2112  .  .  .  .  Name: "SwitchStatementJustOneCaseAndDefault"
-  2113  .  .  .  .  Position: ast.Position {}
-  2114  .  .  .  }
-  2115  .  .  .  Type: *ast.FuncType {
-  2116  .  .  .  .  Position: ast.Position {}
-  2117  .  .  .  .  Params: *ast.FieldList {
-  2118  .  .  .  .  .  Position: ast.Position {}
-  2119  .  .  .  .  }
-  2120  .  .  .  }
-  2121  .  .  .  Body: *ast.BlockStmt {
-  2122  .  .  .  .  Position: ast.Position {}
-  2123  .  .  .  .  List: []ast.Stmt (len = 4) {
-  2124  .  .  .  .  .  0: *ast.ExprStmt {
-  2125  .  .  .  .  .  .  Position: ast.Position {}
-  2126  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2127  .  .  .  .  .  .  .  Position: ast.Position {}
-  2128  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2129  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2130  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2131  .  .  .  .  .  .  .  .  .  Name: "console"
-  2132  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2133  .  .  .  .  .  .  .  .  }
-  2134  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2135  .  .  .  .  .  .  .  .  .  Name: "log"
-  2136  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2137  .  .  .  .  .  .  .  .  }
-  2138  .  .  .  .  .  .  .  }
-  2139  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2140  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2141  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2142  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2143  .  .  .  .  .  .  .  .  .  Value: "switch entry"
-  2144  .  .  .  .  .  .  .  .  }
-  2145  .  .  .  .  .  .  .  }
-  2146  .  .  .  .  .  .  }
-  2147  .  .  .  .  .  }
-  2148  .  .  .  .  .  1: *ast.AssignStmt {
-  2149  .  .  .  .  .  .  Position: ast.Position {}
-  2150  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2151  .  .  .  .  .  .  .  0: *ast.Ident {
-  2152  .  .  .  .  .  .  .  .  Name: "foo"
-  2153  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2154  .  .  .  .  .  .  .  }
-  2155  .  .  .  .  .  .  }
-  2156  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2157  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2158  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2159  .  .  .  .  .  .  .  .  Kind: "number"
-  2160  .  .  .  .  .  .  .  .  Value: "2"
-  2161  .  .  .  .  .  .  .  }
-  2162  .  .  .  .  .  .  }
-  2163  .  .  .  .  .  }
-  2164  .  .  .  .  .  2: *ast.SwitchStatement {
-  2165  .  .  .  .  .  .  Position: ast.Position {}
-  2166  .  .  .  .  .  .  Value: *ast.Ident {
-  2167  .  .  .  .  .  .  .  Name: "foo"
-  2168  .  .  .  .  .  .  .  Position: ast.Position {}
-  2169  .  .  .  .  .  .  }
-  2170  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2171  .  .  .  .  .  .  .  Position: ast.Position {}
-  2172  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
-  2173  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
-  2174  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2175  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
-  2176  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2177  .  .  .  .  .  .  .  .  .  .  Kind: "number"
-  2178  .  .  .  .  .  .  .  .  .  .  Value: "1"
-  2179  .  .  .  .  .  .  .  .  .  }
-  2180  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-  2181  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2182  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2183  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2184  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2185  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2186  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2187  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2188  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2189  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2190  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2191  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2192  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2193  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2194  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2195  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2196  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2197  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2198  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2199  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2200  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
-  2201  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2202  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2203  .  .  .  .  .  .  .  .  .  .  .  }
-  2204  .  .  .  .  .  .  .  .  .  .  }
-  2205  .  .  .  .  .  .  .  .  .  }
-  2206  .  .  .  .  .  .  .  .  }
-  2207  .  .  .  .  .  .  .  .  1: *ast.SwitchDefault {
-  2208  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2209  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
-  2210  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2211  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2212  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2213  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2214  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2215  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2216  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2217  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2218  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2219  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2220  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2221  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2222  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2223  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2224  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2225  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2226  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2227  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2228  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2229  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
-  2230  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2231  .  .  .  .  .  .  .  .  .  .  .  .  }
-  2232  .  .  .  .  .  .  .  .  .  .  .  }
-  2233  .  .  .  .  .  .  .  .  .  .  }
-  2234  .  .  .  .  .  .  .  .  .  }
-  2235  .  .  .  .  .  .  .  .  }
-  2236  .  .  .  .  .  .  .  }
-  2237  .  .  .  .  .  .  }
-  2238  .  .  .  .  .  }
-  2239  .  .  .  .  .  3: *ast.ExprStmt {
-  2240  .  .  .  .  .  .  Position: ast.Position {}
-  2241  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2242  .  .  .  .  .  .  .  Position: ast.Position {}
-  2243  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2244  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2245  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2246  .  .  .  .  .  .  .  .  .  Name: "console"
-  2247  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2248  .  .  .  .  .  .  .  .  }
-  2249  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2250  .  .  .  .  .  .  .  .  .  Name: "log"
-  2251  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2252  .  .  .  .  .  .  .  .  }
-  2253  .  .  .  .  .  .  .  }
-  2254  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2255  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2256  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2257  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2258  .  .  .  .  .  .  .  .  .  Value: "switch done"
-  2259  .  .  .  .  .  .  .  .  }
-  2260  .  .  .  .  .  .  .  }
-  2261  .  .  .  .  .  .  }
-  2262  .  .  .  .  .  }
-  2263  .  .  .  .  }
-  2264  .  .  .  }
-  2265  .  .  }
-  2266  .  .  13: *ast.FuncDecl {
-  2267  .  .  .  Position: ast.Position {}
-  2268  .  .  .  Name: *ast.Ident {
-  2269  .  .  .  .  Name: "ForStatement"
-  2270  .  .  .  .  Position: ast.Position {}
-  2271  .  .  .  }
-  2272  .  .  .  Type: *ast.FuncType {
-  2273  .  .  .  .  Position: ast.Position {}
-  2274  .  .  .  .  Params: *ast.FieldList {
-  2275  .  .  .  .  .  Position: ast.Position {}
-  2276  .  .  .  .  }
-  2277  .  .  .  }
-  2278  .  .  .  Body: *ast.BlockStmt {
-  2279  .  .  .  .  Position: ast.Position {}
-  2280  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2281  .  .  .  .  .  0: *ast.ForStatement {
-  2282  .  .  .  .  .  .  Position: ast.Position {}
-  2283  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
-  2284  .  .  .  .  .  .  .  Position: ast.Position {}
-  2285  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2286  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2287  .  .  .  .  .  .  .  .  .  Name: "i"
-  2288  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2289  .  .  .  .  .  .  .  .  }
-  2290  .  .  .  .  .  .  .  }
-  2291  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2292  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2293  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2294  .  .  .  .  .  .  .  .  .  Kind: "number"
-  2295  .  .  .  .  .  .  .  .  .  Value: "0"
-  2296  .  .  .  .  .  .  .  .  }
-  2297  .  .  .  .  .  .  .  }
-  2298  .  .  .  .  .  .  }
-  2299  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-  2300  .  .  .  .  .  .  .  Position: ast.Position {}
-  2301  .  .  .  .  .  .  .  Left: *ast.Ident {
-  2302  .  .  .  .  .  .  .  .  Name: "i"
-  2303  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2304  .  .  .  .  .  .  .  }
-  2305  .  .  .  .  .  .  .  Op: "<"
-  2306  .  .  .  .  .  .  .  Right: *ast.BasicLit {
-  2307  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2308  .  .  .  .  .  .  .  .  Kind: "number"
-  2309  .  .  .  .  .  .  .  .  Value: "9"
-  2310  .  .  .  .  .  .  .  }
-  2311  .  .  .  .  .  .  }
-  2312  .  .  .  .  .  .  Increment: *ast.IncExpr {
-  2313  .  .  .  .  .  .  .  Position: ast.Position {}
-  2314  .  .  .  .  .  .  .  Op: "++"
-  2315  .  .  .  .  .  .  .  Arg: *ast.Ident {
-  2316  .  .  .  .  .  .  .  .  Name: "i"
-  2317  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2318  .  .  .  .  .  .  .  }
-  2319  .  .  .  .  .  .  }
-  2320  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2321  .  .  .  .  .  .  .  Position: ast.Position {}
-  2322  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2323  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2324  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2325  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2326  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2327  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2328  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2329  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2330  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2331  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2332  .  .  .  .  .  .  .  .  .  .  .  }
-  2333  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2334  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2335  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2336  .  .  .  .  .  .  .  .  .  .  .  }
-  2337  .  .  .  .  .  .  .  .  .  .  }
-  2338  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2339  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2340  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
-  2341  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2342  .  .  .  .  .  .  .  .  .  .  .  }
-  2343  .  .  .  .  .  .  .  .  .  .  }
-  2344  .  .  .  .  .  .  .  .  .  }
-  2345  .  .  .  .  .  .  .  .  }
-  2346  .  .  .  .  .  .  .  }
-  2347  .  .  .  .  .  .  }
-  2348  .  .  .  .  .  }
-  2349  .  .  .  .  }
-  2350  .  .  .  }
-  2351  .  .  }
-  2352  .  .  14: *ast.FuncDecl {
-  2353  .  .  .  Position: ast.Position {}
-  2354  .  .  .  Name: *ast.Ident {
-  2355  .  .  .  .  Name: "ForStatementIteratingOverList"
-  2356  .  .  .  .  Position: ast.Position {}
-  2357  .  .  .  }
-  2358  .  .  .  Type: *ast.FuncType {
-  2359  .  .  .  .  Position: ast.Position {}
-  2360  .  .  .  .  Params: *ast.FieldList {
-  2361  .  .  .  .  .  Position: ast.Position {}
-  2362  .  .  .  .  .  List: []*ast.Field (len = 1) {
-  2363  .  .  .  .  .  .  0: *ast.Field {
-  2364  .  .  .  .  .  .  .  Position: ast.Position {}
-  2365  .  .  .  .  .  .  .  Name: *ast.Ident {
-  2366  .  .  .  .  .  .  .  .  Name: "data"
-  2367  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1990  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  1991  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  1992  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  1993  .  .  .  .  .  .  .  .  Kind: "string"
+  1994  .  .  .  .  .  .  .  .  Value: "Oranges"
+  1995  .  .  .  .  .  .  .  }
+  1996  .  .  .  .  .  .  }
+  1997  .  .  .  .  .  }
+  1998  .  .  .  .  .  2: *ast.SwitchStatement {
+  1999  .  .  .  .  .  .  Position: ast.Position {}
+  2000  .  .  .  .  .  .  Value: *ast.Ident {
+  2001  .  .  .  .  .  .  .  Name: "fruits"
+  2002  .  .  .  .  .  .  .  Position: ast.Position {}
+  2003  .  .  .  .  .  .  }
+  2004  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2005  .  .  .  .  .  .  .  Position: ast.Position {}
+  2006  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2007  .  .  .  .  .  .  .  .  0: *ast.SwitchDefault {
+  2008  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2009  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
+  2010  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2011  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2012  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2013  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2014  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2015  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2016  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2017  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2018  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2019  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2020  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2021  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2022  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2023  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2024  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2025  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2026  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2027  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2028  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2029  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
+  2030  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2031  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2032  .  .  .  .  .  .  .  .  .  .  .  }
+  2033  .  .  .  .  .  .  .  .  .  .  }
+  2034  .  .  .  .  .  .  .  .  .  }
+  2035  .  .  .  .  .  .  .  .  }
+  2036  .  .  .  .  .  .  .  }
+  2037  .  .  .  .  .  .  }
+  2038  .  .  .  .  .  }
+  2039  .  .  .  .  .  3: *ast.ExprStmt {
+  2040  .  .  .  .  .  .  Position: ast.Position {}
+  2041  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2042  .  .  .  .  .  .  .  Position: ast.Position {}
+  2043  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2044  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2045  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2046  .  .  .  .  .  .  .  .  .  Name: "console"
+  2047  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2048  .  .  .  .  .  .  .  .  }
+  2049  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2050  .  .  .  .  .  .  .  .  .  Name: "log"
+  2051  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2052  .  .  .  .  .  .  .  .  }
+  2053  .  .  .  .  .  .  .  }
+  2054  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2055  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2056  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2057  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2058  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  2059  .  .  .  .  .  .  .  .  }
+  2060  .  .  .  .  .  .  .  }
+  2061  .  .  .  .  .  .  }
+  2062  .  .  .  .  .  }
+  2063  .  .  .  .  }
+  2064  .  .  .  }
+  2065  .  .  }
+  2066  .  .  11: *ast.FuncDecl {
+  2067  .  .  .  Position: ast.Position {}
+  2068  .  .  .  Name: *ast.Ident {
+  2069  .  .  .  .  Name: "SwitchStatementOnlyOneCase"
+  2070  .  .  .  .  Position: ast.Position {}
+  2071  .  .  .  }
+  2072  .  .  .  Type: *ast.FuncType {
+  2073  .  .  .  .  Position: ast.Position {}
+  2074  .  .  .  .  Params: *ast.FieldList {
+  2075  .  .  .  .  .  Position: ast.Position {}
+  2076  .  .  .  .  }
+  2077  .  .  .  }
+  2078  .  .  .  Body: *ast.BlockStmt {
+  2079  .  .  .  .  Position: ast.Position {}
+  2080  .  .  .  .  List: []ast.Stmt (len = 4) {
+  2081  .  .  .  .  .  0: *ast.ExprStmt {
+  2082  .  .  .  .  .  .  Position: ast.Position {}
+  2083  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2084  .  .  .  .  .  .  .  Position: ast.Position {}
+  2085  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2086  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2087  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2088  .  .  .  .  .  .  .  .  .  Name: "console"
+  2089  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2090  .  .  .  .  .  .  .  .  }
+  2091  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2092  .  .  .  .  .  .  .  .  .  Name: "log"
+  2093  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2094  .  .  .  .  .  .  .  .  }
+  2095  .  .  .  .  .  .  .  }
+  2096  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2097  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2098  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2099  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2100  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  2101  .  .  .  .  .  .  .  .  }
+  2102  .  .  .  .  .  .  .  }
+  2103  .  .  .  .  .  .  }
+  2104  .  .  .  .  .  }
+  2105  .  .  .  .  .  1: *ast.AssignStmt {
+  2106  .  .  .  .  .  .  Position: ast.Position {}
+  2107  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2108  .  .  .  .  .  .  .  0: *ast.Ident {
+  2109  .  .  .  .  .  .  .  .  Name: "fruits"
+  2110  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2111  .  .  .  .  .  .  .  }
+  2112  .  .  .  .  .  .  }
+  2113  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2114  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2115  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2116  .  .  .  .  .  .  .  .  Kind: "string"
+  2117  .  .  .  .  .  .  .  .  Value: "Oranges"
+  2118  .  .  .  .  .  .  .  }
+  2119  .  .  .  .  .  .  }
+  2120  .  .  .  .  .  }
+  2121  .  .  .  .  .  2: *ast.SwitchStatement {
+  2122  .  .  .  .  .  .  Position: ast.Position {}
+  2123  .  .  .  .  .  .  Value: *ast.Ident {
+  2124  .  .  .  .  .  .  .  Name: "fruits"
+  2125  .  .  .  .  .  .  .  Position: ast.Position {}
+  2126  .  .  .  .  .  .  }
+  2127  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2128  .  .  .  .  .  .  .  Position: ast.Position {}
+  2129  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2130  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
+  2131  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2132  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  2133  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2134  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2135  .  .  .  .  .  .  .  .  .  .  Value: "Oranges"
+  2136  .  .  .  .  .  .  .  .  .  }
+  2137  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  2138  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2139  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2140  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2141  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2142  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2143  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2144  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2145  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2146  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2147  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2148  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2149  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2150  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2151  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2152  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2153  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2154  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2155  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2156  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2157  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
+  2158  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2159  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2160  .  .  .  .  .  .  .  .  .  .  .  }
+  2161  .  .  .  .  .  .  .  .  .  .  }
+  2162  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  2163  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2164  .  .  .  .  .  .  .  .  .  .  }
+  2165  .  .  .  .  .  .  .  .  .  }
+  2166  .  .  .  .  .  .  .  .  }
+  2167  .  .  .  .  .  .  .  }
+  2168  .  .  .  .  .  .  }
+  2169  .  .  .  .  .  }
+  2170  .  .  .  .  .  3: *ast.ExprStmt {
+  2171  .  .  .  .  .  .  Position: ast.Position {}
+  2172  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2173  .  .  .  .  .  .  .  Position: ast.Position {}
+  2174  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2175  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2176  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2177  .  .  .  .  .  .  .  .  .  Name: "console"
+  2178  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2179  .  .  .  .  .  .  .  .  }
+  2180  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2181  .  .  .  .  .  .  .  .  .  Name: "log"
+  2182  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2183  .  .  .  .  .  .  .  .  }
+  2184  .  .  .  .  .  .  .  }
+  2185  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2186  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2187  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2188  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2189  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  2190  .  .  .  .  .  .  .  .  }
+  2191  .  .  .  .  .  .  .  }
+  2192  .  .  .  .  .  .  }
+  2193  .  .  .  .  .  }
+  2194  .  .  .  .  }
+  2195  .  .  .  }
+  2196  .  .  }
+  2197  .  .  12: *ast.FuncDecl {
+  2198  .  .  .  Position: ast.Position {}
+  2199  .  .  .  Name: *ast.Ident {
+  2200  .  .  .  .  Name: "SwitchStatementWithBadNodesAndDefault"
+  2201  .  .  .  .  Position: ast.Position {}
+  2202  .  .  .  }
+  2203  .  .  .  Type: *ast.FuncType {
+  2204  .  .  .  .  Position: ast.Position {}
+  2205  .  .  .  .  Params: *ast.FieldList {
+  2206  .  .  .  .  .  Position: ast.Position {}
+  2207  .  .  .  .  }
+  2208  .  .  .  }
+  2209  .  .  .  Body: *ast.BlockStmt {
+  2210  .  .  .  .  Position: ast.Position {}
+  2211  .  .  .  .  List: []ast.Stmt (len = 4) {
+  2212  .  .  .  .  .  0: *ast.ExprStmt {
+  2213  .  .  .  .  .  .  Position: ast.Position {}
+  2214  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2215  .  .  .  .  .  .  .  Position: ast.Position {}
+  2216  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2217  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2218  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2219  .  .  .  .  .  .  .  .  .  Name: "console"
+  2220  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2221  .  .  .  .  .  .  .  .  }
+  2222  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2223  .  .  .  .  .  .  .  .  .  Name: "log"
+  2224  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2225  .  .  .  .  .  .  .  .  }
+  2226  .  .  .  .  .  .  .  }
+  2227  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2228  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2229  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2230  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2231  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  2232  .  .  .  .  .  .  .  .  }
+  2233  .  .  .  .  .  .  .  }
+  2234  .  .  .  .  .  .  }
+  2235  .  .  .  .  .  }
+  2236  .  .  .  .  .  1: *ast.AssignStmt {
+  2237  .  .  .  .  .  .  Position: ast.Position {}
+  2238  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2239  .  .  .  .  .  .  .  0: *ast.Ident {
+  2240  .  .  .  .  .  .  .  .  Name: "fruits"
+  2241  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2242  .  .  .  .  .  .  .  }
+  2243  .  .  .  .  .  .  }
+  2244  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2245  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2246  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2247  .  .  .  .  .  .  .  .  Kind: "string"
+  2248  .  .  .  .  .  .  .  .  Value: "Oranges"
+  2249  .  .  .  .  .  .  .  }
+  2250  .  .  .  .  .  .  }
+  2251  .  .  .  .  .  }
+  2252  .  .  .  .  .  2: *ast.SwitchStatement {
+  2253  .  .  .  .  .  .  Position: ast.Position {}
+  2254  .  .  .  .  .  .  Value: *ast.Ident {
+  2255  .  .  .  .  .  .  .  Name: "fruits"
+  2256  .  .  .  .  .  .  .  Position: ast.Position {}
+  2257  .  .  .  .  .  .  }
+  2258  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2259  .  .  .  .  .  .  .  Position: ast.Position {}
+  2260  .  .  .  .  .  .  .  List: []ast.Stmt (len = 4) {
+  2261  .  .  .  .  .  .  .  .  0: *ast.BadNode {
+  2262  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2263  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
+  2264  .  .  .  .  .  .  .  .  }
+  2265  .  .  .  .  .  .  .  .  1: *ast.BadNode {
+  2266  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2267  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
+  2268  .  .  .  .  .  .  .  .  }
+  2269  .  .  .  .  .  .  .  .  2: *ast.BadNode {
+  2270  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2271  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
+  2272  .  .  .  .  .  .  .  .  }
+  2273  .  .  .  .  .  .  .  .  3: *ast.SwitchDefault {
+  2274  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2275  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
+  2276  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2277  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2278  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2279  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2280  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2281  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2282  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2283  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2284  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2285  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2286  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2287  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2288  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2289  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2290  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2291  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2292  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2293  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2294  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2295  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
+  2296  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2297  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2298  .  .  .  .  .  .  .  .  .  .  .  }
+  2299  .  .  .  .  .  .  .  .  .  .  }
+  2300  .  .  .  .  .  .  .  .  .  }
+  2301  .  .  .  .  .  .  .  .  }
+  2302  .  .  .  .  .  .  .  }
+  2303  .  .  .  .  .  .  }
+  2304  .  .  .  .  .  }
+  2305  .  .  .  .  .  3: *ast.ExprStmt {
+  2306  .  .  .  .  .  .  Position: ast.Position {}
+  2307  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2308  .  .  .  .  .  .  .  Position: ast.Position {}
+  2309  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2310  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2311  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2312  .  .  .  .  .  .  .  .  .  Name: "console"
+  2313  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2314  .  .  .  .  .  .  .  .  }
+  2315  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2316  .  .  .  .  .  .  .  .  .  Name: "log"
+  2317  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2318  .  .  .  .  .  .  .  .  }
+  2319  .  .  .  .  .  .  .  }
+  2320  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2321  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2322  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2323  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2324  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  2325  .  .  .  .  .  .  .  .  }
+  2326  .  .  .  .  .  .  .  }
+  2327  .  .  .  .  .  .  }
+  2328  .  .  .  .  .  }
+  2329  .  .  .  .  }
+  2330  .  .  .  }
+  2331  .  .  }
+  2332  .  .  13: *ast.FuncDecl {
+  2333  .  .  .  Position: ast.Position {}
+  2334  .  .  .  Name: *ast.Ident {
+  2335  .  .  .  .  Name: "SwitchStatementWithBadNode"
+  2336  .  .  .  .  Position: ast.Position {}
+  2337  .  .  .  }
+  2338  .  .  .  Type: *ast.FuncType {
+  2339  .  .  .  .  Position: ast.Position {}
+  2340  .  .  .  .  Params: *ast.FieldList {
+  2341  .  .  .  .  .  Position: ast.Position {}
+  2342  .  .  .  .  }
+  2343  .  .  .  }
+  2344  .  .  .  Body: *ast.BlockStmt {
+  2345  .  .  .  .  Position: ast.Position {}
+  2346  .  .  .  .  List: []ast.Stmt (len = 4) {
+  2347  .  .  .  .  .  0: *ast.ExprStmt {
+  2348  .  .  .  .  .  .  Position: ast.Position {}
+  2349  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2350  .  .  .  .  .  .  .  Position: ast.Position {}
+  2351  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2352  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2353  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2354  .  .  .  .  .  .  .  .  .  Name: "console"
+  2355  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2356  .  .  .  .  .  .  .  .  }
+  2357  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2358  .  .  .  .  .  .  .  .  .  Name: "log"
+  2359  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2360  .  .  .  .  .  .  .  .  }
+  2361  .  .  .  .  .  .  .  }
+  2362  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2363  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2364  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2365  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2366  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  2367  .  .  .  .  .  .  .  .  }
   2368  .  .  .  .  .  .  .  }
   2369  .  .  .  .  .  .  }
   2370  .  .  .  .  .  }
-  2371  .  .  .  .  }
-  2372  .  .  .  }
-  2373  .  .  .  Body: *ast.BlockStmt {
-  2374  .  .  .  .  Position: ast.Position {}
-  2375  .  .  .  .  List: []ast.Stmt (len = 3) {
-  2376  .  .  .  .  .  0: *ast.AssignStmt {
-  2377  .  .  .  .  .  .  Position: ast.Position {}
-  2378  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2379  .  .  .  .  .  .  .  0: *ast.Ident {
-  2380  .  .  .  .  .  .  .  .  Name: "sum"
+  2371  .  .  .  .  .  1: *ast.AssignStmt {
+  2372  .  .  .  .  .  .  Position: ast.Position {}
+  2373  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2374  .  .  .  .  .  .  .  0: *ast.Ident {
+  2375  .  .  .  .  .  .  .  .  Name: "fruits"
+  2376  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2377  .  .  .  .  .  .  .  }
+  2378  .  .  .  .  .  .  }
+  2379  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2380  .  .  .  .  .  .  .  0: *ast.BasicLit {
   2381  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2382  .  .  .  .  .  .  .  }
-  2383  .  .  .  .  .  .  }
-  2384  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2385  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2386  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2387  .  .  .  .  .  .  .  .  Kind: "number"
-  2388  .  .  .  .  .  .  .  .  Value: "0"
-  2389  .  .  .  .  .  .  .  }
-  2390  .  .  .  .  .  .  }
-  2391  .  .  .  .  .  }
-  2392  .  .  .  .  .  1: *ast.ForStatement {
-  2393  .  .  .  .  .  .  Position: ast.Position {}
-  2394  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
-  2395  .  .  .  .  .  .  .  Position: ast.Position {}
-  2396  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2397  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2398  .  .  .  .  .  .  .  .  .  Name: "i"
-  2399  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2400  .  .  .  .  .  .  .  .  }
-  2401  .  .  .  .  .  .  .  }
-  2402  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2403  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2404  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2405  .  .  .  .  .  .  .  .  .  Kind: "number"
-  2406  .  .  .  .  .  .  .  .  .  Value: "0"
+  2382  .  .  .  .  .  .  .  .  Kind: "string"
+  2383  .  .  .  .  .  .  .  .  Value: "Oranges"
+  2384  .  .  .  .  .  .  .  }
+  2385  .  .  .  .  .  .  }
+  2386  .  .  .  .  .  }
+  2387  .  .  .  .  .  2: *ast.SwitchStatement {
+  2388  .  .  .  .  .  .  Position: ast.Position {}
+  2389  .  .  .  .  .  .  Value: *ast.Ident {
+  2390  .  .  .  .  .  .  .  Name: "fruits"
+  2391  .  .  .  .  .  .  .  Position: ast.Position {}
+  2392  .  .  .  .  .  .  }
+  2393  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2394  .  .  .  .  .  .  .  Position: ast.Position {}
+  2395  .  .  .  .  .  .  .  List: []ast.Stmt (len = 5) {
+  2396  .  .  .  .  .  .  .  .  0: *ast.BadNode {
+  2397  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2398  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
+  2399  .  .  .  .  .  .  .  .  }
+  2400  .  .  .  .  .  .  .  .  1: *ast.BadNode {
+  2401  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2402  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
+  2403  .  .  .  .  .  .  .  .  }
+  2404  .  .  .  .  .  .  .  .  2: *ast.BadNode {
+  2405  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2406  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <comment>"
   2407  .  .  .  .  .  .  .  .  }
-  2408  .  .  .  .  .  .  .  }
-  2409  .  .  .  .  .  .  }
-  2410  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-  2411  .  .  .  .  .  .  .  Position: ast.Position {}
-  2412  .  .  .  .  .  .  .  Left: *ast.Ident {
-  2413  .  .  .  .  .  .  .  .  Name: "i"
-  2414  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2415  .  .  .  .  .  .  .  }
-  2416  .  .  .  .  .  .  .  Op: "<"
-  2417  .  .  .  .  .  .  .  Right: *ast.SelectorExpr {
-  2418  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2419  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2420  .  .  .  .  .  .  .  .  .  Name: "data"
-  2421  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2422  .  .  .  .  .  .  .  .  }
-  2423  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2424  .  .  .  .  .  .  .  .  .  Name: "length"
-  2425  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2426  .  .  .  .  .  .  .  .  }
-  2427  .  .  .  .  .  .  .  }
-  2428  .  .  .  .  .  .  }
-  2429  .  .  .  .  .  .  Increment: *ast.IncExpr {
-  2430  .  .  .  .  .  .  .  Position: ast.Position {}
-  2431  .  .  .  .  .  .  .  Op: "++"
-  2432  .  .  .  .  .  .  .  Arg: *ast.Ident {
-  2433  .  .  .  .  .  .  .  .  Name: "i"
-  2434  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2435  .  .  .  .  .  .  .  }
-  2436  .  .  .  .  .  .  }
-  2437  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2438  .  .  .  .  .  .  .  Position: ast.Position {}
-  2439  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2440  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2441  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2442  .  .  .  .  .  .  .  .  .  Expr: *ast.BadNode {
-  2443  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2444  .  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <augmented_assignment_expression>"
-  2445  .  .  .  .  .  .  .  .  .  }
-  2446  .  .  .  .  .  .  .  .  }
-  2447  .  .  .  .  .  .  .  }
-  2448  .  .  .  .  .  .  }
-  2449  .  .  .  .  .  }
-  2450  .  .  .  .  .  2: *ast.ReturnStmt {
-  2451  .  .  .  .  .  .  Position: ast.Position {}
-  2452  .  .  .  .  .  .  Results: []ast.Expr (len = 1) {
-  2453  .  .  .  .  .  .  .  0: *ast.Ident {
-  2454  .  .  .  .  .  .  .  .  Name: "sum"
-  2455  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2456  .  .  .  .  .  .  .  }
-  2457  .  .  .  .  .  .  }
-  2458  .  .  .  .  .  }
-  2459  .  .  .  .  }
-  2460  .  .  .  }
-  2461  .  .  }
-  2462  .  .  15: *ast.FuncDecl {
-  2463  .  .  .  Position: ast.Position {}
-  2464  .  .  .  Name: *ast.Ident {
-  2465  .  .  .  .  Name: "ForStatementWithoutBinaryExpressionIncremet"
-  2466  .  .  .  .  Position: ast.Position {}
-  2467  .  .  .  }
-  2468  .  .  .  Type: *ast.FuncType {
-  2469  .  .  .  .  Position: ast.Position {}
-  2470  .  .  .  .  Params: *ast.FieldList {
-  2471  .  .  .  .  .  Position: ast.Position {}
-  2472  .  .  .  .  }
-  2473  .  .  .  }
-  2474  .  .  .  Body: *ast.BlockStmt {
-  2475  .  .  .  .  Position: ast.Position {}
-  2476  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2477  .  .  .  .  .  0: *ast.ForStatement {
-  2478  .  .  .  .  .  .  Position: ast.Position {}
-  2479  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
-  2480  .  .  .  .  .  .  .  Position: ast.Position {}
-  2481  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 2) {
-  2482  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2483  .  .  .  .  .  .  .  .  .  Name: "a"
-  2484  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2485  .  .  .  .  .  .  .  .  }
-  2486  .  .  .  .  .  .  .  .  1: *ast.Ident {
-  2487  .  .  .  .  .  .  .  .  .  Name: "b"
-  2488  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2489  .  .  .  .  .  .  .  .  }
-  2490  .  .  .  .  .  .  .  }
-  2491  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 0) {}
-  2492  .  .  .  .  .  .  }
-  2493  .  .  .  .  .  .  Cond: *ast.Ident {
-  2494  .  .  .  .  .  .  .  Name: "c"
-  2495  .  .  .  .  .  .  .  Position: ast.Position {}
-  2496  .  .  .  .  .  .  }
-  2497  .  .  .  .  .  .  Increment: *ast.Ident {
-  2498  .  .  .  .  .  .  .  Name: "d"
-  2499  .  .  .  .  .  .  .  Position: ast.Position {}
-  2500  .  .  .  .  .  .  }
-  2501  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2502  .  .  .  .  .  .  .  Position: ast.Position {}
-  2503  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2504  .  .  .  .  .  .  .  .  0: *ast.BadNode {
-  2505  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2506  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <identifier>"
-  2507  .  .  .  .  .  .  .  .  }
-  2508  .  .  .  .  .  .  .  }
-  2509  .  .  .  .  .  .  }
-  2510  .  .  .  .  .  }
-  2511  .  .  .  .  }
-  2512  .  .  .  }
-  2513  .  .  }
-  2514  .  .  16: *ast.FuncDecl {
-  2515  .  .  .  Position: ast.Position {}
-  2516  .  .  .  Name: *ast.Ident {
-  2517  .  .  .  .  Name: "ForStatementEndlessRecursion"
-  2518  .  .  .  .  Position: ast.Position {}
-  2519  .  .  .  }
-  2520  .  .  .  Type: *ast.FuncType {
-  2521  .  .  .  .  Position: ast.Position {}
-  2522  .  .  .  .  Params: *ast.FieldList {
-  2523  .  .  .  .  .  Position: ast.Position {}
-  2524  .  .  .  .  }
-  2525  .  .  .  }
-  2526  .  .  .  Body: *ast.BlockStmt {
-  2527  .  .  .  .  Position: ast.Position {}
-  2528  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2529  .  .  .  .  .  0: *ast.ForStatement {
-  2530  .  .  .  .  .  .  Position: ast.Position {}
-  2531  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2532  .  .  .  .  .  .  .  Position: ast.Position {}
-  2533  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2534  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2408  .  .  .  .  .  .  .  .  3: *ast.SwitchCase {
+  2409  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2410  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  2411  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2412  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2413  .  .  .  .  .  .  .  .  .  .  Value: "Mangoes"
+  2414  .  .  .  .  .  .  .  .  .  }
+  2415  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  2416  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2417  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2418  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2419  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2420  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2421  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2422  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2423  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2424  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2425  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2426  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2427  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2428  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2429  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2430  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2431  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2432  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2433  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2434  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2435  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 2"
+  2436  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2437  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2438  .  .  .  .  .  .  .  .  .  .  .  }
+  2439  .  .  .  .  .  .  .  .  .  .  }
+  2440  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  2441  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2442  .  .  .  .  .  .  .  .  .  .  }
+  2443  .  .  .  .  .  .  .  .  .  }
+  2444  .  .  .  .  .  .  .  .  }
+  2445  .  .  .  .  .  .  .  .  4: *ast.SwitchCase {
+  2446  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2447  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  2448  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2449  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2450  .  .  .  .  .  .  .  .  .  .  Value: "Papayas"
+  2451  .  .  .  .  .  .  .  .  .  }
+  2452  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 2) {
+  2453  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2454  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2455  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2456  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2457  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2458  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2459  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2460  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2461  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2462  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2463  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2464  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2465  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2466  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2467  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2468  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2469  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2470  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2471  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2472  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 3"
+  2473  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2474  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2475  .  .  .  .  .  .  .  .  .  .  .  }
+  2476  .  .  .  .  .  .  .  .  .  .  }
+  2477  .  .  .  .  .  .  .  .  .  .  1: *ast.BreakStatement {
+  2478  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2479  .  .  .  .  .  .  .  .  .  .  }
+  2480  .  .  .  .  .  .  .  .  .  }
+  2481  .  .  .  .  .  .  .  .  }
+  2482  .  .  .  .  .  .  .  }
+  2483  .  .  .  .  .  .  }
+  2484  .  .  .  .  .  }
+  2485  .  .  .  .  .  3: *ast.ExprStmt {
+  2486  .  .  .  .  .  .  Position: ast.Position {}
+  2487  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2488  .  .  .  .  .  .  .  Position: ast.Position {}
+  2489  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2490  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2491  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2492  .  .  .  .  .  .  .  .  .  Name: "console"
+  2493  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2494  .  .  .  .  .  .  .  .  }
+  2495  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2496  .  .  .  .  .  .  .  .  .  Name: "log"
+  2497  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2498  .  .  .  .  .  .  .  .  }
+  2499  .  .  .  .  .  .  .  }
+  2500  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2501  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2502  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2503  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2504  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  2505  .  .  .  .  .  .  .  .  }
+  2506  .  .  .  .  .  .  .  }
+  2507  .  .  .  .  .  .  }
+  2508  .  .  .  .  .  }
+  2509  .  .  .  .  }
+  2510  .  .  .  }
+  2511  .  .  }
+  2512  .  .  14: *ast.FuncDecl {
+  2513  .  .  .  Position: ast.Position {}
+  2514  .  .  .  Name: *ast.Ident {
+  2515  .  .  .  .  Name: "SwitchStatementJustOneCaseAndDefault"
+  2516  .  .  .  .  Position: ast.Position {}
+  2517  .  .  .  }
+  2518  .  .  .  Type: *ast.FuncType {
+  2519  .  .  .  .  Position: ast.Position {}
+  2520  .  .  .  .  Params: *ast.FieldList {
+  2521  .  .  .  .  .  Position: ast.Position {}
+  2522  .  .  .  .  }
+  2523  .  .  .  }
+  2524  .  .  .  Body: *ast.BlockStmt {
+  2525  .  .  .  .  Position: ast.Position {}
+  2526  .  .  .  .  List: []ast.Stmt (len = 4) {
+  2527  .  .  .  .  .  0: *ast.ExprStmt {
+  2528  .  .  .  .  .  .  Position: ast.Position {}
+  2529  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2530  .  .  .  .  .  .  .  Position: ast.Position {}
+  2531  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2532  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2533  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2534  .  .  .  .  .  .  .  .  .  Name: "console"
   2535  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2536  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2537  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2538  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2539  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2540  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2541  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2542  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2543  .  .  .  .  .  .  .  .  .  .  .  }
-  2544  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2545  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2546  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2547  .  .  .  .  .  .  .  .  .  .  .  }
-  2548  .  .  .  .  .  .  .  .  .  .  }
-  2549  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2550  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2551  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2552  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2553  .  .  .  .  .  .  .  .  .  .  .  .  Value: "endless recursion"
-  2554  .  .  .  .  .  .  .  .  .  .  .  }
-  2555  .  .  .  .  .  .  .  .  .  .  }
-  2556  .  .  .  .  .  .  .  .  .  }
-  2557  .  .  .  .  .  .  .  .  }
-  2558  .  .  .  .  .  .  .  }
-  2559  .  .  .  .  .  .  }
-  2560  .  .  .  .  .  }
-  2561  .  .  .  .  }
-  2562  .  .  .  }
-  2563  .  .  }
-  2564  .  .  17: *ast.FuncDecl {
-  2565  .  .  .  Position: ast.Position {}
-  2566  .  .  .  Name: *ast.Ident {
-  2567  .  .  .  .  Name: "ForStatementEmptyBody"
-  2568  .  .  .  .  Position: ast.Position {}
-  2569  .  .  .  }
-  2570  .  .  .  Type: *ast.FuncType {
-  2571  .  .  .  .  Position: ast.Position {}
-  2572  .  .  .  .  Params: *ast.FieldList {
-  2573  .  .  .  .  .  Position: ast.Position {}
-  2574  .  .  .  .  }
-  2575  .  .  .  }
-  2576  .  .  .  Body: *ast.BlockStmt {
-  2577  .  .  .  .  Position: ast.Position {}
-  2578  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2579  .  .  .  .  .  0: *ast.ForStatement {
-  2580  .  .  .  .  .  .  Position: ast.Position {}
-  2581  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
-  2582  .  .  .  .  .  .  .  Position: ast.Position {}
-  2583  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2584  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2585  .  .  .  .  .  .  .  .  .  Name: "i"
-  2586  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2587  .  .  .  .  .  .  .  .  }
-  2588  .  .  .  .  .  .  .  }
-  2589  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2590  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2591  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2592  .  .  .  .  .  .  .  .  .  Kind: "number"
-  2593  .  .  .  .  .  .  .  .  .  Value: "0"
-  2594  .  .  .  .  .  .  .  .  }
-  2595  .  .  .  .  .  .  .  }
-  2596  .  .  .  .  .  .  }
-  2597  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
-  2598  .  .  .  .  .  .  .  Position: ast.Position {}
-  2599  .  .  .  .  .  .  .  Left: *ast.Ident {
-  2600  .  .  .  .  .  .  .  .  Name: "i"
-  2601  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2602  .  .  .  .  .  .  .  }
-  2603  .  .  .  .  .  .  .  Op: "<"
-  2604  .  .  .  .  .  .  .  Right: *ast.Ident {
-  2605  .  .  .  .  .  .  .  .  Name: "l"
-  2606  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2607  .  .  .  .  .  .  .  }
-  2608  .  .  .  .  .  .  }
-  2609  .  .  .  .  .  .  Increment: *ast.IncExpr {
-  2610  .  .  .  .  .  .  .  Position: ast.Position {}
-  2611  .  .  .  .  .  .  .  Op: "++"
-  2612  .  .  .  .  .  .  .  Arg: *ast.Ident {
-  2613  .  .  .  .  .  .  .  .  Name: "i"
-  2614  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2615  .  .  .  .  .  .  .  }
-  2616  .  .  .  .  .  .  }
-  2617  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2618  .  .  .  .  .  .  .  Position: ast.Position {}
-  2619  .  .  .  .  .  .  .  List: []ast.Stmt (len = 0) {}
-  2620  .  .  .  .  .  .  }
-  2621  .  .  .  .  .  }
-  2622  .  .  .  .  }
-  2623  .  .  .  }
-  2624  .  .  }
-  2625  .  .  18: *ast.FuncDecl {
-  2626  .  .  .  Position: ast.Position {}
-  2627  .  .  .  Name: *ast.Ident {
-  2628  .  .  .  .  Name: "ForInStatement"
-  2629  .  .  .  .  Position: ast.Position {}
-  2630  .  .  .  }
-  2631  .  .  .  Type: *ast.FuncType {
-  2632  .  .  .  .  Position: ast.Position {}
-  2633  .  .  .  .  Params: *ast.FieldList {
-  2634  .  .  .  .  .  Position: ast.Position {}
-  2635  .  .  .  .  }
-  2636  .  .  .  }
-  2637  .  .  .  Body: *ast.BlockStmt {
-  2638  .  .  .  .  Position: ast.Position {}
-  2639  .  .  .  .  List: []ast.Stmt (len = 2) {
-  2640  .  .  .  .  .  0: *ast.AssignStmt {
-  2641  .  .  .  .  .  .  Position: ast.Position {}
-  2642  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
-  2643  .  .  .  .  .  .  .  0: *ast.Ident {
-  2644  .  .  .  .  .  .  .  .  Name: "values"
-  2645  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2646  .  .  .  .  .  .  .  }
-  2647  .  .  .  .  .  .  }
-  2648  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
-  2649  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
-  2650  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2651  .  .  .  .  .  .  .  .  Elts: []ast.Expr (len = 3) {
-  2652  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
-  2653  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2654  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2655  .  .  .  .  .  .  .  .  .  .  Value: "a"
-  2656  .  .  .  .  .  .  .  .  .  }
-  2657  .  .  .  .  .  .  .  .  .  1: *ast.BasicLit {
-  2658  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2659  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2660  .  .  .  .  .  .  .  .  .  .  Value: "b"
-  2661  .  .  .  .  .  .  .  .  .  }
-  2662  .  .  .  .  .  .  .  .  .  2: *ast.BasicLit {
-  2663  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2664  .  .  .  .  .  .  .  .  .  .  Kind: "string"
-  2665  .  .  .  .  .  .  .  .  .  .  Value: "c"
-  2666  .  .  .  .  .  .  .  .  .  }
-  2667  .  .  .  .  .  .  .  .  }
-  2668  .  .  .  .  .  .  .  .  Comment: "array"
-  2669  .  .  .  .  .  .  .  }
-  2670  .  .  .  .  .  .  }
-  2671  .  .  .  .  .  }
-  2672  .  .  .  .  .  1: *ast.ForInStatement {
-  2673  .  .  .  .  .  .  Position: ast.Position {}
-  2674  .  .  .  .  .  .  Left: *ast.Ident {
-  2675  .  .  .  .  .  .  .  Name: "value"
-  2676  .  .  .  .  .  .  .  Position: ast.Position {}
-  2677  .  .  .  .  .  .  }
-  2678  .  .  .  .  .  .  Right: *ast.Ident {
-  2679  .  .  .  .  .  .  .  Name: "values"
-  2680  .  .  .  .  .  .  .  Position: ast.Position {}
-  2681  .  .  .  .  .  .  }
-  2682  .  .  .  .  .  .  Body: *ast.BlockStmt {
-  2683  .  .  .  .  .  .  .  Position: ast.Position {}
-  2684  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2685  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
-  2686  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2687  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
-  2688  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2689  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
-  2690  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2691  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
-  2692  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
-  2693  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2694  .  .  .  .  .  .  .  .  .  .  .  }
-  2695  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
-  2696  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
-  2697  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2698  .  .  .  .  .  .  .  .  .  .  .  }
-  2699  .  .  .  .  .  .  .  .  .  .  }
-  2700  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
-  2701  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
-  2702  .  .  .  .  .  .  .  .  .  .  .  .  Name: "value"
-  2703  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
-  2704  .  .  .  .  .  .  .  .  .  .  .  }
-  2705  .  .  .  .  .  .  .  .  .  .  }
-  2706  .  .  .  .  .  .  .  .  .  }
-  2707  .  .  .  .  .  .  .  .  }
-  2708  .  .  .  .  .  .  .  }
-  2709  .  .  .  .  .  .  }
-  2710  .  .  .  .  .  }
-  2711  .  .  .  .  }
-  2712  .  .  .  }
-  2713  .  .  }
-  2714  .  .  19: *ast.FuncDecl {
-  2715  .  .  .  Position: ast.Position {}
-  2716  .  .  .  Name: *ast.Ident {
-  2717  .  .  .  .  Name: "ExportStatement"
-  2718  .  .  .  .  Position: ast.Position {}
-  2719  .  .  .  }
-  2720  .  .  .  Type: *ast.FuncType {
-  2721  .  .  .  .  Position: ast.Position {}
-  2722  .  .  .  .  Params: *ast.FieldList {
-  2723  .  .  .  .  .  Position: ast.Position {}
-  2724  .  .  .  .  }
-  2725  .  .  .  }
-  2726  .  .  .  Body: *ast.BlockStmt {
-  2727  .  .  .  .  Position: ast.Position {}
-  2728  .  .  .  .  List: []ast.Stmt (len = 1) {
-  2729  .  .  .  .  .  0: nil
-  2730  .  .  .  .  }
-  2731  .  .  .  }
-  2732  .  .  }
-  2733  .  }
-  2734  }
+  2536  .  .  .  .  .  .  .  .  }
+  2537  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2538  .  .  .  .  .  .  .  .  .  Name: "log"
+  2539  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2540  .  .  .  .  .  .  .  .  }
+  2541  .  .  .  .  .  .  .  }
+  2542  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2543  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2544  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2545  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2546  .  .  .  .  .  .  .  .  .  Value: "switch entry"
+  2547  .  .  .  .  .  .  .  .  }
+  2548  .  .  .  .  .  .  .  }
+  2549  .  .  .  .  .  .  }
+  2550  .  .  .  .  .  }
+  2551  .  .  .  .  .  1: *ast.AssignStmt {
+  2552  .  .  .  .  .  .  Position: ast.Position {}
+  2553  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2554  .  .  .  .  .  .  .  0: *ast.Ident {
+  2555  .  .  .  .  .  .  .  .  Name: "foo"
+  2556  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2557  .  .  .  .  .  .  .  }
+  2558  .  .  .  .  .  .  }
+  2559  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2560  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2561  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2562  .  .  .  .  .  .  .  .  Kind: "number"
+  2563  .  .  .  .  .  .  .  .  Value: "2"
+  2564  .  .  .  .  .  .  .  }
+  2565  .  .  .  .  .  .  }
+  2566  .  .  .  .  .  }
+  2567  .  .  .  .  .  2: *ast.SwitchStatement {
+  2568  .  .  .  .  .  .  Position: ast.Position {}
+  2569  .  .  .  .  .  .  Value: *ast.Ident {
+  2570  .  .  .  .  .  .  .  Name: "foo"
+  2571  .  .  .  .  .  .  .  Position: ast.Position {}
+  2572  .  .  .  .  .  .  }
+  2573  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2574  .  .  .  .  .  .  .  Position: ast.Position {}
+  2575  .  .  .  .  .  .  .  List: []ast.Stmt (len = 2) {
+  2576  .  .  .  .  .  .  .  .  0: *ast.SwitchCase {
+  2577  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2578  .  .  .  .  .  .  .  .  .  Cond: *ast.BasicLit {
+  2579  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2580  .  .  .  .  .  .  .  .  .  .  Kind: "number"
+  2581  .  .  .  .  .  .  .  .  .  .  Value: "1"
+  2582  .  .  .  .  .  .  .  .  .  }
+  2583  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
+  2584  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2585  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2586  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2587  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2588  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2589  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2590  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2591  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2592  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2593  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2594  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2595  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2596  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2597  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2598  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2599  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2600  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2601  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2602  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2603  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case 1"
+  2604  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2605  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2606  .  .  .  .  .  .  .  .  .  .  .  }
+  2607  .  .  .  .  .  .  .  .  .  .  }
+  2608  .  .  .  .  .  .  .  .  .  }
+  2609  .  .  .  .  .  .  .  .  }
+  2610  .  .  .  .  .  .  .  .  1: *ast.SwitchDefault {
+  2611  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2612  .  .  .  .  .  .  .  .  .  Body: []ast.Stmt (len = 1) {
+  2613  .  .  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2614  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2615  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2616  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2617  .  .  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2618  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2619  .  .  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2620  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2621  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2622  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2623  .  .  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2624  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2625  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2626  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2627  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2628  .  .  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2629  .  .  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2630  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2631  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2632  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Value: "switch case default"
+  2633  .  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2634  .  .  .  .  .  .  .  .  .  .  .  .  }
+  2635  .  .  .  .  .  .  .  .  .  .  .  }
+  2636  .  .  .  .  .  .  .  .  .  .  }
+  2637  .  .  .  .  .  .  .  .  .  }
+  2638  .  .  .  .  .  .  .  .  }
+  2639  .  .  .  .  .  .  .  }
+  2640  .  .  .  .  .  .  }
+  2641  .  .  .  .  .  }
+  2642  .  .  .  .  .  3: *ast.ExprStmt {
+  2643  .  .  .  .  .  .  Position: ast.Position {}
+  2644  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2645  .  .  .  .  .  .  .  Position: ast.Position {}
+  2646  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2647  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2648  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2649  .  .  .  .  .  .  .  .  .  Name: "console"
+  2650  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2651  .  .  .  .  .  .  .  .  }
+  2652  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2653  .  .  .  .  .  .  .  .  .  Name: "log"
+  2654  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2655  .  .  .  .  .  .  .  .  }
+  2656  .  .  .  .  .  .  .  }
+  2657  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2658  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2659  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2660  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2661  .  .  .  .  .  .  .  .  .  Value: "switch done"
+  2662  .  .  .  .  .  .  .  .  }
+  2663  .  .  .  .  .  .  .  }
+  2664  .  .  .  .  .  .  }
+  2665  .  .  .  .  .  }
+  2666  .  .  .  .  }
+  2667  .  .  .  }
+  2668  .  .  }
+  2669  .  .  15: *ast.FuncDecl {
+  2670  .  .  .  Position: ast.Position {}
+  2671  .  .  .  Name: *ast.Ident {
+  2672  .  .  .  .  Name: "ForStatement"
+  2673  .  .  .  .  Position: ast.Position {}
+  2674  .  .  .  }
+  2675  .  .  .  Type: *ast.FuncType {
+  2676  .  .  .  .  Position: ast.Position {}
+  2677  .  .  .  .  Params: *ast.FieldList {
+  2678  .  .  .  .  .  Position: ast.Position {}
+  2679  .  .  .  .  }
+  2680  .  .  .  }
+  2681  .  .  .  Body: *ast.BlockStmt {
+  2682  .  .  .  .  Position: ast.Position {}
+  2683  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2684  .  .  .  .  .  0: *ast.ForStatement {
+  2685  .  .  .  .  .  .  Position: ast.Position {}
+  2686  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  2687  .  .  .  .  .  .  .  Position: ast.Position {}
+  2688  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2689  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  2690  .  .  .  .  .  .  .  .  .  Name: "i"
+  2691  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2692  .  .  .  .  .  .  .  .  }
+  2693  .  .  .  .  .  .  .  }
+  2694  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2695  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2696  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2697  .  .  .  .  .  .  .  .  .  Kind: "number"
+  2698  .  .  .  .  .  .  .  .  .  Value: "0"
+  2699  .  .  .  .  .  .  .  .  }
+  2700  .  .  .  .  .  .  .  }
+  2701  .  .  .  .  .  .  }
+  2702  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  2703  .  .  .  .  .  .  .  Position: ast.Position {}
+  2704  .  .  .  .  .  .  .  Left: *ast.Ident {
+  2705  .  .  .  .  .  .  .  .  Name: "i"
+  2706  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2707  .  .  .  .  .  .  .  }
+  2708  .  .  .  .  .  .  .  Op: "<"
+  2709  .  .  .  .  .  .  .  Right: *ast.BasicLit {
+  2710  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2711  .  .  .  .  .  .  .  .  Kind: "number"
+  2712  .  .  .  .  .  .  .  .  Value: "9"
+  2713  .  .  .  .  .  .  .  }
+  2714  .  .  .  .  .  .  }
+  2715  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  2716  .  .  .  .  .  .  .  Position: ast.Position {}
+  2717  .  .  .  .  .  .  .  Op: "++"
+  2718  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  2719  .  .  .  .  .  .  .  .  Name: "i"
+  2720  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2721  .  .  .  .  .  .  .  }
+  2722  .  .  .  .  .  .  }
+  2723  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2724  .  .  .  .  .  .  .  Position: ast.Position {}
+  2725  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2726  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2727  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2728  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2729  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2730  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2731  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2732  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2733  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2734  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2735  .  .  .  .  .  .  .  .  .  .  .  }
+  2736  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2737  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2738  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2739  .  .  .  .  .  .  .  .  .  .  .  }
+  2740  .  .  .  .  .  .  .  .  .  .  }
+  2741  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2742  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  2743  .  .  .  .  .  .  .  .  .  .  .  .  Name: "i"
+  2744  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2745  .  .  .  .  .  .  .  .  .  .  .  }
+  2746  .  .  .  .  .  .  .  .  .  .  }
+  2747  .  .  .  .  .  .  .  .  .  }
+  2748  .  .  .  .  .  .  .  .  }
+  2749  .  .  .  .  .  .  .  }
+  2750  .  .  .  .  .  .  }
+  2751  .  .  .  .  .  }
+  2752  .  .  .  .  }
+  2753  .  .  .  }
+  2754  .  .  }
+  2755  .  .  16: *ast.FuncDecl {
+  2756  .  .  .  Position: ast.Position {}
+  2757  .  .  .  Name: *ast.Ident {
+  2758  .  .  .  .  Name: "ForStatementIteratingOverList"
+  2759  .  .  .  .  Position: ast.Position {}
+  2760  .  .  .  }
+  2761  .  .  .  Type: *ast.FuncType {
+  2762  .  .  .  .  Position: ast.Position {}
+  2763  .  .  .  .  Params: *ast.FieldList {
+  2764  .  .  .  .  .  Position: ast.Position {}
+  2765  .  .  .  .  .  List: []*ast.Field (len = 1) {
+  2766  .  .  .  .  .  .  0: *ast.Field {
+  2767  .  .  .  .  .  .  .  Position: ast.Position {}
+  2768  .  .  .  .  .  .  .  Name: *ast.Ident {
+  2769  .  .  .  .  .  .  .  .  Name: "data"
+  2770  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2771  .  .  .  .  .  .  .  }
+  2772  .  .  .  .  .  .  }
+  2773  .  .  .  .  .  }
+  2774  .  .  .  .  }
+  2775  .  .  .  }
+  2776  .  .  .  Body: *ast.BlockStmt {
+  2777  .  .  .  .  Position: ast.Position {}
+  2778  .  .  .  .  List: []ast.Stmt (len = 3) {
+  2779  .  .  .  .  .  0: *ast.AssignStmt {
+  2780  .  .  .  .  .  .  Position: ast.Position {}
+  2781  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2782  .  .  .  .  .  .  .  0: *ast.Ident {
+  2783  .  .  .  .  .  .  .  .  Name: "sum"
+  2784  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2785  .  .  .  .  .  .  .  }
+  2786  .  .  .  .  .  .  }
+  2787  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2788  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2789  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2790  .  .  .  .  .  .  .  .  Kind: "number"
+  2791  .  .  .  .  .  .  .  .  Value: "0"
+  2792  .  .  .  .  .  .  .  }
+  2793  .  .  .  .  .  .  }
+  2794  .  .  .  .  .  }
+  2795  .  .  .  .  .  1: *ast.ForStatement {
+  2796  .  .  .  .  .  .  Position: ast.Position {}
+  2797  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  2798  .  .  .  .  .  .  .  Position: ast.Position {}
+  2799  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2800  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  2801  .  .  .  .  .  .  .  .  .  Name: "i"
+  2802  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2803  .  .  .  .  .  .  .  .  }
+  2804  .  .  .  .  .  .  .  }
+  2805  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2806  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2807  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2808  .  .  .  .  .  .  .  .  .  Kind: "number"
+  2809  .  .  .  .  .  .  .  .  .  Value: "0"
+  2810  .  .  .  .  .  .  .  .  }
+  2811  .  .  .  .  .  .  .  }
+  2812  .  .  .  .  .  .  }
+  2813  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  2814  .  .  .  .  .  .  .  Position: ast.Position {}
+  2815  .  .  .  .  .  .  .  Left: *ast.Ident {
+  2816  .  .  .  .  .  .  .  .  Name: "i"
+  2817  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2818  .  .  .  .  .  .  .  }
+  2819  .  .  .  .  .  .  .  Op: "<"
+  2820  .  .  .  .  .  .  .  Right: *ast.SelectorExpr {
+  2821  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2822  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2823  .  .  .  .  .  .  .  .  .  Name: "data"
+  2824  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2825  .  .  .  .  .  .  .  .  }
+  2826  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2827  .  .  .  .  .  .  .  .  .  Name: "length"
+  2828  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2829  .  .  .  .  .  .  .  .  }
+  2830  .  .  .  .  .  .  .  }
+  2831  .  .  .  .  .  .  }
+  2832  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  2833  .  .  .  .  .  .  .  Position: ast.Position {}
+  2834  .  .  .  .  .  .  .  Op: "++"
+  2835  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  2836  .  .  .  .  .  .  .  .  Name: "i"
+  2837  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2838  .  .  .  .  .  .  .  }
+  2839  .  .  .  .  .  .  }
+  2840  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2841  .  .  .  .  .  .  .  Position: ast.Position {}
+  2842  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2843  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2844  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2845  .  .  .  .  .  .  .  .  .  Expr: *ast.BadNode {
+  2846  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2847  .  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <augmented_assignment_expression>"
+  2848  .  .  .  .  .  .  .  .  .  }
+  2849  .  .  .  .  .  .  .  .  }
+  2850  .  .  .  .  .  .  .  }
+  2851  .  .  .  .  .  .  }
+  2852  .  .  .  .  .  }
+  2853  .  .  .  .  .  2: *ast.ReturnStmt {
+  2854  .  .  .  .  .  .  Position: ast.Position {}
+  2855  .  .  .  .  .  .  Results: []ast.Expr (len = 1) {
+  2856  .  .  .  .  .  .  .  0: *ast.Ident {
+  2857  .  .  .  .  .  .  .  .  Name: "sum"
+  2858  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2859  .  .  .  .  .  .  .  }
+  2860  .  .  .  .  .  .  }
+  2861  .  .  .  .  .  }
+  2862  .  .  .  .  }
+  2863  .  .  .  }
+  2864  .  .  }
+  2865  .  .  17: *ast.FuncDecl {
+  2866  .  .  .  Position: ast.Position {}
+  2867  .  .  .  Name: *ast.Ident {
+  2868  .  .  .  .  Name: "ForStatementWithoutBinaryExpressionIncremet"
+  2869  .  .  .  .  Position: ast.Position {}
+  2870  .  .  .  }
+  2871  .  .  .  Type: *ast.FuncType {
+  2872  .  .  .  .  Position: ast.Position {}
+  2873  .  .  .  .  Params: *ast.FieldList {
+  2874  .  .  .  .  .  Position: ast.Position {}
+  2875  .  .  .  .  }
+  2876  .  .  .  }
+  2877  .  .  .  Body: *ast.BlockStmt {
+  2878  .  .  .  .  Position: ast.Position {}
+  2879  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2880  .  .  .  .  .  0: *ast.ForStatement {
+  2881  .  .  .  .  .  .  Position: ast.Position {}
+  2882  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  2883  .  .  .  .  .  .  .  Position: ast.Position {}
+  2884  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 2) {
+  2885  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  2886  .  .  .  .  .  .  .  .  .  Name: "a"
+  2887  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2888  .  .  .  .  .  .  .  .  }
+  2889  .  .  .  .  .  .  .  .  1: *ast.Ident {
+  2890  .  .  .  .  .  .  .  .  .  Name: "b"
+  2891  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2892  .  .  .  .  .  .  .  .  }
+  2893  .  .  .  .  .  .  .  }
+  2894  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 0) {}
+  2895  .  .  .  .  .  .  }
+  2896  .  .  .  .  .  .  Cond: *ast.Ident {
+  2897  .  .  .  .  .  .  .  Name: "c"
+  2898  .  .  .  .  .  .  .  Position: ast.Position {}
+  2899  .  .  .  .  .  .  }
+  2900  .  .  .  .  .  .  Increment: *ast.Ident {
+  2901  .  .  .  .  .  .  .  Name: "d"
+  2902  .  .  .  .  .  .  .  Position: ast.Position {}
+  2903  .  .  .  .  .  .  }
+  2904  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2905  .  .  .  .  .  .  .  Position: ast.Position {}
+  2906  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2907  .  .  .  .  .  .  .  .  0: *ast.BadNode {
+  2908  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2909  .  .  .  .  .  .  .  .  .  Comment: "unsupported node type <identifier>"
+  2910  .  .  .  .  .  .  .  .  }
+  2911  .  .  .  .  .  .  .  }
+  2912  .  .  .  .  .  .  }
+  2913  .  .  .  .  .  }
+  2914  .  .  .  .  }
+  2915  .  .  .  }
+  2916  .  .  }
+  2917  .  .  18: *ast.FuncDecl {
+  2918  .  .  .  Position: ast.Position {}
+  2919  .  .  .  Name: *ast.Ident {
+  2920  .  .  .  .  Name: "ForStatementEndlessRecursion"
+  2921  .  .  .  .  Position: ast.Position {}
+  2922  .  .  .  }
+  2923  .  .  .  Type: *ast.FuncType {
+  2924  .  .  .  .  Position: ast.Position {}
+  2925  .  .  .  .  Params: *ast.FieldList {
+  2926  .  .  .  .  .  Position: ast.Position {}
+  2927  .  .  .  .  }
+  2928  .  .  .  }
+  2929  .  .  .  Body: *ast.BlockStmt {
+  2930  .  .  .  .  Position: ast.Position {}
+  2931  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2932  .  .  .  .  .  0: *ast.ForStatement {
+  2933  .  .  .  .  .  .  Position: ast.Position {}
+  2934  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  2935  .  .  .  .  .  .  .  Position: ast.Position {}
+  2936  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2937  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  2938  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2939  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  2940  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2941  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  2942  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2943  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  2944  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  2945  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2946  .  .  .  .  .  .  .  .  .  .  .  }
+  2947  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  2948  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  2949  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2950  .  .  .  .  .  .  .  .  .  .  .  }
+  2951  .  .  .  .  .  .  .  .  .  .  }
+  2952  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  2953  .  .  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2954  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2955  .  .  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  2956  .  .  .  .  .  .  .  .  .  .  .  .  Value: "endless recursion"
+  2957  .  .  .  .  .  .  .  .  .  .  .  }
+  2958  .  .  .  .  .  .  .  .  .  .  }
+  2959  .  .  .  .  .  .  .  .  .  }
+  2960  .  .  .  .  .  .  .  .  }
+  2961  .  .  .  .  .  .  .  }
+  2962  .  .  .  .  .  .  }
+  2963  .  .  .  .  .  }
+  2964  .  .  .  .  }
+  2965  .  .  .  }
+  2966  .  .  }
+  2967  .  .  19: *ast.FuncDecl {
+  2968  .  .  .  Position: ast.Position {}
+  2969  .  .  .  Name: *ast.Ident {
+  2970  .  .  .  .  Name: "ForStatementEmptyBody"
+  2971  .  .  .  .  Position: ast.Position {}
+  2972  .  .  .  }
+  2973  .  .  .  Type: *ast.FuncType {
+  2974  .  .  .  .  Position: ast.Position {}
+  2975  .  .  .  .  Params: *ast.FieldList {
+  2976  .  .  .  .  .  Position: ast.Position {}
+  2977  .  .  .  .  }
+  2978  .  .  .  }
+  2979  .  .  .  Body: *ast.BlockStmt {
+  2980  .  .  .  .  Position: ast.Position {}
+  2981  .  .  .  .  List: []ast.Stmt (len = 1) {
+  2982  .  .  .  .  .  0: *ast.ForStatement {
+  2983  .  .  .  .  .  .  Position: ast.Position {}
+  2984  .  .  .  .  .  .  VarDecl: *ast.AssignStmt {
+  2985  .  .  .  .  .  .  .  Position: ast.Position {}
+  2986  .  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  2987  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  2988  .  .  .  .  .  .  .  .  .  Name: "i"
+  2989  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2990  .  .  .  .  .  .  .  .  }
+  2991  .  .  .  .  .  .  .  }
+  2992  .  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  2993  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  2994  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  2995  .  .  .  .  .  .  .  .  .  Kind: "number"
+  2996  .  .  .  .  .  .  .  .  .  Value: "0"
+  2997  .  .  .  .  .  .  .  .  }
+  2998  .  .  .  .  .  .  .  }
+  2999  .  .  .  .  .  .  }
+  3000  .  .  .  .  .  .  Cond: *ast.BinaryExpr {
+  3001  .  .  .  .  .  .  .  Position: ast.Position {}
+  3002  .  .  .  .  .  .  .  Left: *ast.Ident {
+  3003  .  .  .  .  .  .  .  .  Name: "i"
+  3004  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3005  .  .  .  .  .  .  .  }
+  3006  .  .  .  .  .  .  .  Op: "<"
+  3007  .  .  .  .  .  .  .  Right: *ast.Ident {
+  3008  .  .  .  .  .  .  .  .  Name: "l"
+  3009  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3010  .  .  .  .  .  .  .  }
+  3011  .  .  .  .  .  .  }
+  3012  .  .  .  .  .  .  Increment: *ast.IncExpr {
+  3013  .  .  .  .  .  .  .  Position: ast.Position {}
+  3014  .  .  .  .  .  .  .  Op: "++"
+  3015  .  .  .  .  .  .  .  Arg: *ast.Ident {
+  3016  .  .  .  .  .  .  .  .  Name: "i"
+  3017  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3018  .  .  .  .  .  .  .  }
+  3019  .  .  .  .  .  .  }
+  3020  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  3021  .  .  .  .  .  .  .  Position: ast.Position {}
+  3022  .  .  .  .  .  .  .  List: []ast.Stmt (len = 0) {}
+  3023  .  .  .  .  .  .  }
+  3024  .  .  .  .  .  }
+  3025  .  .  .  .  }
+  3026  .  .  .  }
+  3027  .  .  }
+  3028  .  .  20: *ast.FuncDecl {
+  3029  .  .  .  Position: ast.Position {}
+  3030  .  .  .  Name: *ast.Ident {
+  3031  .  .  .  .  Name: "ForInStatement"
+  3032  .  .  .  .  Position: ast.Position {}
+  3033  .  .  .  }
+  3034  .  .  .  Type: *ast.FuncType {
+  3035  .  .  .  .  Position: ast.Position {}
+  3036  .  .  .  .  Params: *ast.FieldList {
+  3037  .  .  .  .  .  Position: ast.Position {}
+  3038  .  .  .  .  }
+  3039  .  .  .  }
+  3040  .  .  .  Body: *ast.BlockStmt {
+  3041  .  .  .  .  Position: ast.Position {}
+  3042  .  .  .  .  List: []ast.Stmt (len = 2) {
+  3043  .  .  .  .  .  0: *ast.AssignStmt {
+  3044  .  .  .  .  .  .  Position: ast.Position {}
+  3045  .  .  .  .  .  .  LHS: []ast.Expr (len = 1) {
+  3046  .  .  .  .  .  .  .  0: *ast.Ident {
+  3047  .  .  .  .  .  .  .  .  Name: "values"
+  3048  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3049  .  .  .  .  .  .  .  }
+  3050  .  .  .  .  .  .  }
+  3051  .  .  .  .  .  .  RHS: []ast.Expr (len = 1) {
+  3052  .  .  .  .  .  .  .  0: *ast.ObjectExpr {
+  3053  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3054  .  .  .  .  .  .  .  .  Elts: []ast.Expr (len = 3) {
+  3055  .  .  .  .  .  .  .  .  .  0: *ast.BasicLit {
+  3056  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3057  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  3058  .  .  .  .  .  .  .  .  .  .  Value: "a"
+  3059  .  .  .  .  .  .  .  .  .  }
+  3060  .  .  .  .  .  .  .  .  .  1: *ast.BasicLit {
+  3061  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3062  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  3063  .  .  .  .  .  .  .  .  .  .  Value: "b"
+  3064  .  .  .  .  .  .  .  .  .  }
+  3065  .  .  .  .  .  .  .  .  .  2: *ast.BasicLit {
+  3066  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3067  .  .  .  .  .  .  .  .  .  .  Kind: "string"
+  3068  .  .  .  .  .  .  .  .  .  .  Value: "c"
+  3069  .  .  .  .  .  .  .  .  .  }
+  3070  .  .  .  .  .  .  .  .  }
+  3071  .  .  .  .  .  .  .  .  Comment: "array"
+  3072  .  .  .  .  .  .  .  }
+  3073  .  .  .  .  .  .  }
+  3074  .  .  .  .  .  }
+  3075  .  .  .  .  .  1: *ast.ForInStatement {
+  3076  .  .  .  .  .  .  Position: ast.Position {}
+  3077  .  .  .  .  .  .  Left: *ast.Ident {
+  3078  .  .  .  .  .  .  .  Name: "value"
+  3079  .  .  .  .  .  .  .  Position: ast.Position {}
+  3080  .  .  .  .  .  .  }
+  3081  .  .  .  .  .  .  Right: *ast.Ident {
+  3082  .  .  .  .  .  .  .  Name: "values"
+  3083  .  .  .  .  .  .  .  Position: ast.Position {}
+  3084  .  .  .  .  .  .  }
+  3085  .  .  .  .  .  .  Body: *ast.BlockStmt {
+  3086  .  .  .  .  .  .  .  Position: ast.Position {}
+  3087  .  .  .  .  .  .  .  List: []ast.Stmt (len = 1) {
+  3088  .  .  .  .  .  .  .  .  0: *ast.ExprStmt {
+  3089  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3090  .  .  .  .  .  .  .  .  .  Expr: *ast.CallExpr {
+  3091  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3092  .  .  .  .  .  .  .  .  .  .  Fun: *ast.SelectorExpr {
+  3093  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3094  .  .  .  .  .  .  .  .  .  .  .  Expr: *ast.Ident {
+  3095  .  .  .  .  .  .  .  .  .  .  .  .  Name: "console"
+  3096  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3097  .  .  .  .  .  .  .  .  .  .  .  }
+  3098  .  .  .  .  .  .  .  .  .  .  .  Sel: *ast.Ident {
+  3099  .  .  .  .  .  .  .  .  .  .  .  .  Name: "log"
+  3100  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3101  .  .  .  .  .  .  .  .  .  .  .  }
+  3102  .  .  .  .  .  .  .  .  .  .  }
+  3103  .  .  .  .  .  .  .  .  .  .  Args: []ast.Expr (len = 1) {
+  3104  .  .  .  .  .  .  .  .  .  .  .  0: *ast.Ident {
+  3105  .  .  .  .  .  .  .  .  .  .  .  .  Name: "value"
+  3106  .  .  .  .  .  .  .  .  .  .  .  .  Position: ast.Position {}
+  3107  .  .  .  .  .  .  .  .  .  .  .  }
+  3108  .  .  .  .  .  .  .  .  .  .  }
+  3109  .  .  .  .  .  .  .  .  .  }
+  3110  .  .  .  .  .  .  .  .  }
+  3111  .  .  .  .  .  .  .  }
+  3112  .  .  .  .  .  .  }
+  3113  .  .  .  .  .  }
+  3114  .  .  .  .  }
+  3115  .  .  .  }
+  3116  .  .  }
+  3117  .  .  21: *ast.FuncDecl {
+  3118  .  .  .  Position: ast.Position {}
+  3119  .  .  .  Name: *ast.Ident {
+  3120  .  .  .  .  Name: "ExportStatement"
+  3121  .  .  .  .  Position: ast.Position {}
+  3122  .  .  .  }
+  3123  .  .  .  Type: *ast.FuncType {
+  3124  .  .  .  .  Position: ast.Position {}
+  3125  .  .  .  .  Params: *ast.FieldList {
+  3126  .  .  .  .  .  Position: ast.Position {}
+  3127  .  .  .  .  }
+  3128  .  .  .  }
+  3129  .  .  .  Body: *ast.BlockStmt {
+  3130  .  .  .  .  Position: ast.Position {}
+  3131  .  .  .  .  List: []ast.Stmt (len = 1) {
+  3132  .  .  .  .  .  0: nil
+  3133  .  .  .  .  }
+  3134  .  .  .  }
+  3135  .  .  }
+  3136  .  }
+  3137  }

--- a/internal/testdata/expected/javascript/ir/statements.js.out
+++ b/internal/testdata/expected/javascript/ir/statements.js.out
@@ -7,7 +7,9 @@ file statements.js:
   func  ForStatementIteratingOverList               (data)
   func  ForStatementWithoutBinaryExpressionIncremet ()
   func  IfStatement                                 (a, b)
+  func  LabeledForStatement                         ()
   func  LabeledWhileStatement                       ()
+  func  NestedForStatement                          ()
   func  SwitchStatement                             ()
   func  SwitchStatementJustOneCaseAndDefault        ()
   func  SwitchStatementOnlyDefault                  ()
@@ -26,13 +28,13 @@ file statements.js:
 
 # Name: ExportStatement
 # File: statements.js
-# Location: statements.js:263:0
+# Location: statements.js:297:0
 func ExportStatement():
 0:                                                                         entry
 
 # Name: ForInStatement
 # File: statements.js
-# Location: statements.js:255:0
+# Location: statements.js:289:0
 # Locals:
 #   0:	values
 func ForInStatement():
@@ -41,7 +43,7 @@ func ForInStatement():
 
 # Name: ForStatement
 # File: statements.js
-# Location: statements.js:221:0
+# Location: statements.js:255:0
 # Locals:
 #   0:	i
 #   1:	i
@@ -62,7 +64,7 @@ func ForStatement():
 
 # Name: ForStatementEmptyBody
 # File: statements.js
-# Location: statements.js:248:0
+# Location: statements.js:282:0
 # Locals:
 #   0:	i
 #   1:	i
@@ -82,7 +84,7 @@ func ForStatementEmptyBody():
 
 # Name: ForStatementEndlessRecursion
 # File: statements.js
-# Location: statements.js:242:0
+# Location: statements.js:276:0
 func ForStatementEndlessRecursion():
 0:                                                                         entry
 	jump 1
@@ -93,7 +95,7 @@ func ForStatementEndlessRecursion():
 
 # Name: ForStatementIteratingOverList
 # File: statements.js
-# Location: statements.js:228:0
+# Location: statements.js:262:0
 # Locals:
 #   0:	i
 #   1:	i
@@ -117,7 +119,7 @@ func ForStatementIteratingOverList(data):
 
 # Name: ForStatementWithoutBinaryExpressionIncremet
 # File: statements.js
-# Location: statements.js:237:0
+# Location: statements.js:271:0
 func ForStatementWithoutBinaryExpressionIncremet():
 0:                                                                         entry
 	jump 2
@@ -160,18 +162,160 @@ func IfStatement(a, b):
 	jump 5
 7:                                                                   unreachable
 
+# Name: LabeledForStatement
+# File: statements.js
+# Location: statements.js:107:0
+# Locals:
+#   0:	i
+#   1:	i
+#   2:	i
+#   3:	j
+#   4:	j
+#   5:	j
+func LabeledForStatement():
+0:                                                                         entry
+	jump 1
+1:                                                                         outer
+	jump 3
+2:                                                                      for.body
+	%t3 = %t1 + "1"
+	jump 6
+3:                                                                      for.loop
+	%t0 = "0"
+	%t1 = phi [3: %t0, 2: %t3] #i
+	%t2 = %t1 < "20"
+	if %t2 goto 2 else 4
+4:                                                                      for.done
+5:                                                                      for.body
+	%t7 = %t5 + "1"
+	%t8 = %t7 == %t3
+	if %t8 goto 8 else 9
+6:                                                                      for.loop
+	%t4 = "0"
+	%t5 = phi [6: %t4, 5: %t7] #j
+	%t6 = %t5 < "10"
+	if %t6 goto 5 else 7
+7:                                                                      for.done
+	%t11 = %t3 % "2"
+	%t12 = %t11 === "0"
+	if %t12 goto 14 else 15
+8:                                                                       if.then
+	jump 3
+9:                                                                       if.done
+	%t9 = %t7 / "5"
+	%t10 = %t9 > "2"
+	if %t10 goto 11 else 12
+10:                                                                  unreachable
+	jump 9
+11:                                                                      if.then
+	jump 7
+12:                                                                      if.done
+	jump 6
+13:                                                                  unreachable
+	jump 12
+14:                                                                      if.then
+	jump 4
+15:                                                                      if.done
+	jump 3
+16:                                                                  unreachable
+	jump 15
+
 # Name: LabeledWhileStatement
 # File: statements.js
 # Location: statements.js:91:0
 # Locals:
 #   0:	x
+#   1:	x
 func LabeledWhileStatement():
 0:                                                                         entry
 	%t0 = "0"
+	jump 1
+1:                                                                     whileStmt
+	jump 3
+2:                                                                    while.body
+	%t2 = console.log("test")
+	%t3 = i === "4"
+	if %t3 goto 5 else 6
+3:                                                                    while.cond
+	%t1 = %t0 <= "5"
+	if %t1 goto 2 else 4
+4:                                                                    while.done
+5:                                                                       if.then
+	%t4 = console.log("finish")
+	jump 4
+6:                                                                       if.done
+	%t5 = i === "2"
+	if %t5 goto 8 else 9
+7:                                                                   unreachable
+	jump 6
+8:                                                                       if.then
+	%t6 = console.log("two")
+	jump 3
+9:                                                                       if.done
+	%t7 = %t0 + "1"
+	jump 3
+10:                                                                  unreachable
+	jump 9
+
+# Name: NestedForStatement
+# File: statements.js
+# Location: statements.js:124:0
+# Locals:
+#   0:	i
+#   1:	i
+#   2:	i
+#   3:	j
+#   4:	j
+#   5:	j
+func NestedForStatement():
+0:                                                                         entry
+	jump 2
+1:                                                                      for.body
+	%t3 = %t1 + "1"
+	jump 5
+2:                                                                      for.loop
+	%t0 = "0"
+	%t1 = phi [2: %t0, 1: %t3] #i
+	%t2 = %t1 < "20"
+	if %t2 goto 1 else 3
+3:                                                                      for.done
+4:                                                                      for.body
+	%t7 = %t5 + "1"
+	%t8 = %t7 == %t3
+	if %t8 goto 7 else 8
+5:                                                                      for.loop
+	%t4 = "0"
+	%t5 = phi [5: %t4, 4: %t7] #j
+	%t6 = %t5 < "10"
+	if %t6 goto 4 else 6
+6:                                                                      for.done
+	%t11 = %t3 % "2"
+	%t12 = %t11 === "0"
+	if %t12 goto 13 else 14
+7:                                                                       if.then
+	jump 5
+8:                                                                       if.done
+	%t9 = %t7 / "5"
+	%t10 = %t9 > "2"
+	if %t10 goto 10 else 11
+9:                                                                   unreachable
+	jump 8
+10:                                                                      if.then
+	jump 6
+11:                                                                      if.done
+	jump 5
+12:                                                                  unreachable
+	jump 11
+13:                                                                      if.then
+	jump 3
+14:                                                                      if.done
+	jump 2
+15:                                                                  unreachable
+	jump 14
 
 # Name: SwitchStatement
 # File: statements.js
-# Location: statements.js:107:0
+# Location: statements.js:141:0
 # Locals:
 #   0:	fruits
 func SwitchStatement():
@@ -203,7 +347,7 @@ func SwitchStatement():
 
 # Name: SwitchStatementJustOneCaseAndDefault
 # File: statements.js
-# Location: statements.js:207:0
+# Location: statements.js:241:0
 # Locals:
 #   0:	foo
 func SwitchStatementJustOneCaseAndDefault():
@@ -224,7 +368,7 @@ func SwitchStatementJustOneCaseAndDefault():
 
 # Name: SwitchStatementOnlyDefault
 # File: statements.js
-# Location: statements.js:147:0
+# Location: statements.js:181:0
 # Locals:
 #   0:	fruits
 func SwitchStatementOnlyDefault():
@@ -240,7 +384,7 @@ func SwitchStatementOnlyDefault():
 
 # Name: SwitchStatementOnlyOneCase
 # File: statements.js
-# Location: statements.js:160:0
+# Location: statements.js:194:0
 # Locals:
 #   0:	fruits
 func SwitchStatementOnlyOneCase():
@@ -258,7 +402,7 @@ func SwitchStatementOnlyOneCase():
 
 # Name: SwitchStatementWithBadNode
 # File: statements.js
-# Location: statements.js:188:0
+# Location: statements.js:222:0
 # Locals:
 #   0:	fruits
 func SwitchStatementWithBadNode():
@@ -281,7 +425,7 @@ func SwitchStatementWithBadNode():
 
 # Name: SwitchStatementWithBadNodesAndDefault
 # File: statements.js
-# Location: statements.js:173:0
+# Location: statements.js:207:0
 # Locals:
 #   0:	fruits
 func SwitchStatementWithBadNodesAndDefault():
@@ -297,7 +441,7 @@ func SwitchStatementWithBadNodesAndDefault():
 
 # Name: SwitchStatementWithoutDefault
 # File: statements.js
-# Location: statements.js:128:0
+# Location: statements.js:162:0
 # Locals:
 #   0:	fruits
 func SwitchStatementWithoutDefault():
@@ -399,14 +543,18 @@ func WhileStatement():
 	%t8 = console.log("finish")
 4:                                                                       if.then
 	%t4 = console.log("two")
-	jump 5
+	jump 2
 5:                                                                       if.done
 	%t5 = %t0 === "4"
-	if %t5 goto 6 else 7
-6:                                                                       if.then
+	if %t5 goto 7 else 8
+6:                                                                   unreachable
+	jump 5
+7:                                                                       if.then
 	%t6 = console.log("finish")
-	jump 7
-7:                                                                       if.done
+	jump 3
+8:                                                                       if.done
 	%t7 = %t0 + "1"
 	jump 2
+9:                                                                   unreachable
+	jump 8
 

--- a/internal/testdata/source/javascript/statements.js
+++ b/internal/testdata/source/javascript/statements.js
@@ -104,6 +104,40 @@ function LabeledWhileStatement() {
     }
 }
 
+function LabeledForStatement() {
+    outer: for (let i = 0; i < 20; i++) {
+        for (let j = 0; j < 10; j++) {
+            if (j == i) {
+                continue outer;
+            }
+            if (j / 5 > 2) {
+                break;
+            }
+        }
+        if (i % 2 === 0) {
+            break;
+        }
+
+    }
+}
+
+function NestedForStatement() {
+    for (let i = 0; i < 20; i++) {
+        for (let j = 0; j < 10; j++) {
+            if (j == i) {
+                continue;
+            }
+            if (j / 5 > 2) {
+                break;
+            }
+        }
+        if (i % 2 === 0) {
+            break;
+        }
+
+    }
+}
+
 function SwitchStatement() {
     console.log("switch entry")
     let fruits = 'Oranges'


### PR DESCRIPTION
This commit add support for labeled statements (for/while/switch).

To add this support a new struct `lblock` was created to store the
blocks that is used to jump when parsing for/while/switch statements
body. A stack is created to store these blocks when processing the
statements, basically, when entering a for/while/switch stmt we push a
new target and after the processing the stmt body we pop the target and
we processing an `break` or `continue` we just get the head of stack to
jump it. A map of labeled blocks was also implemented to store blocks
that are labeled, so if a block has a label we get the block to jump
from this map, otherwise we get the head of stack to jump it.

This commit also improve the generated AST for labeled statements,
instead of store a list of []ast.Stmt we just store the body of labeled
block, which makes parse in the IR easier.

