### PR TITLE
[engine][bugfix]: Fixed bug where Horusec couldn't properly differentiate between .git/ and .github/ path

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"context"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -177,5 +178,5 @@ func (e *Engine) isInvalidExtension(path string) bool {
 
 // isFileFromGitFolder check if a file is in a .git folder
 func (e *Engine) isFileFromGitFolder(path string) bool {
-	return strings.Contains(path, ".git")
+	return strings.Contains(path, ".git"+string(os.PathSeparator))
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -55,7 +55,7 @@ func TestEngineRun(t *testing.T) {
 			projectPath:      filepath.Join("text", "examples"),
 			extensions:       []string{AcceptAnyExtension},
 			rules:            newRuleMock([]Finding{{}}, nil),
-			expectedFindings: 225,
+			expectedFindings: 237,
 			err:              false,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: guilhermepaulozup <guilherme.paulo@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-engine/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Added a call to _os.PathSeparator_ to _isFileFromGitFolder_ to form a _.git/_ path.

This way the engine can properly differentiate between the .git/ directory and .github/ directory (used in Github Actions) files.

**- How to verify it**

Running ```horusec start --log-level="debug"``` should properly read the files in .github/workflows/ folder.

**- Description for the changelog**
Changed _isFileFromGitFolder_ to include on the return: ```".git"+string(os.PathSeparator)```

